### PR TITLE
fix: cond.wait() not in for condition loop

### DIFF
--- a/blocking.go
+++ b/blocking.go
@@ -71,7 +71,7 @@ func (bq *Blocking[T]) OfferWait(elem T) {
 	bq.lock.Lock()
 	defer bq.lock.Unlock()
 
-	if bq.isFull() {
+	for bq.isFull() {
 		bq.notFullCond.Wait()
 	}
 
@@ -209,7 +209,7 @@ func (bq *Blocking[T]) PeekWait() T {
 	bq.lock.Lock()
 	defer bq.lock.Unlock()
 
-	if bq.isEmpty() {
+	for bq.isEmpty() {
 		bq.notEmptyCond.Wait()
 	}
 


### PR DESCRIPTION
Usually, cond.wait() needs to be placed in a loop because it is not possible to know whether the condition has been satisfied when the cond is awakened. This is also explained in the comments of cond.wait() in the official library.

Based on my test case, the following concurrency errors may occur if the code is not modified:
<img width="790" alt="image" src="https://user-images.githubusercontent.com/47981483/236286093-90126e66-fe49-4349-abbb-cb09d656b225.png">

Reference:
https://pkg.go.dev/sync#Cond.Wait
https://www.reddit.com/r/golang/comments/s6tuq3/why_synccond_needs_a_condition_in_for_loop_why/