### PR TITLE
Perf improvements, bug fixes, and cleanup across queue implementations

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -22,16 +22,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: go
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,33 @@
+name: dependabot-auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: auto-merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve PR
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -9,7 +9,7 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/grype.yaml
+++ b/.github/workflows/grype.yaml
@@ -15,8 +15,8 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: anchore/scan-action@v6
+      - uses: actions/checkout@v6
+      - uses: anchore/scan-action@v7
         with:
           path: "."
           fail-build: true

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -39,9 +39,20 @@ jobs:
       - name: Test
         run: make test-ci
 
+      - name: Enforce 100% coverage
+        run: |
+          go tool cover -func=coverage.txt
+          total=$(go tool cover -func=coverage.txt | awk '/^total:/ {print $3}')
+          if [ "$total" != "100.0%" ]; then
+            echo "::error::coverage $total is below required 100.0%"
+            go tool cover -func=coverage.txt | awk '$3 != "100.0%" && NF == 3'
+            exit 1
+          fi
+          echo "coverage: $total"
+
       - name: Upload coverage report
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.txt
+          files: ./coverage.txt
           flags: unittests

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
           args: --timeout 5m
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
 
@@ -40,7 +40,7 @@ jobs:
         run: make test-ci
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 coverage.txt
 coverage.out
 coverage.xml
+.claude
+.env

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,11 +6,13 @@ linters:
   enable:
     - bidichk
     - bodyclose
+    - canonicalheader
     - containedctx
     - contextcheck
     - decorder
     - dupl
     - dupword
+    - embeddedstructfieldcheck
     - err113
     - errcheck
     - errchkjson
@@ -19,6 +21,7 @@ linters:
     - exptostd
     - fatcontext
     - forcetypeassert
+    - funcorder
     - gochecksumtype
     - gocognit
     - goconst
@@ -45,17 +48,28 @@ linters:
     - reassign
     - recvcheck
     - revive
+    - sloglint
+    - spancheck
     - staticcheck
     - tagalign
     - tagliatelle
     - testableexamples
+    - testifylint
     - thelper
     - unused
     - usestdlibvars
     - usetesting
     - varnamelen
-    - wsl
+    - wsl_v5
   settings:
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
+    funcorder:
+      constructor: true
+      struct-method: true
+      alphabetical: false
     dupl:
       threshold: 300
     errcheck:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -181,8 +181,6 @@ linters:
           - err113
           - errcheck
           - forcetypeassert
-          - gocognit
-          - gocyclo
           - gosec
           - nilnil
           - varnamelen

--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,14 @@ test:
 test-ci:
 	go test -mod=mod -shuffle=on -race -timeout 60s -coverprofile=coverage.txt -covermode=atomic .
 
+test-coverage: test-ci
+	@total=$$(go tool cover -func=coverage.txt | awk '/^total:/ {print $$3}'); \
+	if [ "$$total" != "100.0%" ]; then \
+		echo "coverage $$total is below required 100.0%"; \
+		go tool cover -func=coverage.txt | awk '$$3 != "100.0%" && NF == 3'; \
+		exit 1; \
+	fi; \
+	echo "coverage: $$total"
+
 benchmark:
 	go test -bench=.  -benchmem

--- a/blocking.go
+++ b/blocking.go
@@ -156,8 +156,8 @@ func (bq *Blocking[T]) Clear() []T {
 // Iterator returns an iterator over the elements in this queue.
 // It removes the elements from the queue.
 func (bq *Blocking[T]) Iterator() <-chan T {
-	bq.lock.RLock()
-	defer bq.lock.RUnlock()
+	bq.lock.Lock()
+	defer bq.lock.Unlock()
 
 	// use a buffered channel to avoid blocking the iterator.
 	iteratorCh := make(chan T, bq.size())

--- a/blocking_test.go
+++ b/blocking_test.go
@@ -17,445 +17,306 @@ import (
 func TestBlocking(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Consistency", func(t *testing.T) {
-		t.Parallel()
+	t.Run("Consistency", testBlockingConsistency)
+	t.Run("Clear", testBlockingClear)
+	t.Run("Contains", testBlockingContains)
+	t.Run("Iterator", testBlockingIterator)
+	t.Run("IsEmpty", testBlockingIsEmpty)
+	t.Run("Reset", testBlockingReset)
+	t.Run("OfferWait", testBlockingOfferWait)
+	t.Run("Offer", testBlockingOffer)
+	t.Run("Peek", testBlockingPeek)
+	t.Run("PeekWait", testBlockingPeekWait)
+	t.Run("Get", testBlockingGet)
+	t.Run("WithCapacity", testBlockingWithCapacity)
+	t.Run("CondWaitWithCapacity", testBlockingCondWaitWithCapacity)
+	t.Run("MarshalJSON", testBlockingMarshalJSON)
+}
 
-		t.Run("SequentialIteration", func(t *testing.T) {
-			t.Parallel()
+func testBlockingConsistency(t *testing.T) {
+	t.Parallel()
 
-			elems := []int{1, 2, 3}
-
-			blockingQueue := queue.NewBlocking(elems)
-
-			for j := range elems {
-				elem := blockingQueue.GetWait()
-
-				if elems[j] != elem {
-					t.Fatalf("expected elem to be %d, got %d", elems[j], elem)
-				}
-			}
-		})
-
-		t.Run("100ConcurrentGoroutinesReading", func(t *testing.T) {
-			t.Parallel()
-
-			const lenElements = 100
-
-			ids := make([]int, lenElements)
-
-			for i := 1; i <= lenElements; i++ {
-				ids[i-1] = i
-			}
-
-			blockingQueue := queue.NewBlocking(ids)
-
-			var (
-				wg          sync.WaitGroup
-				resultMutex sync.Mutex
-			)
-
-			wg.Add(lenElements)
-
-			result := make([]int, 0, lenElements)
-
-			for i := 0; i < lenElements; i++ {
-				go func() {
-					elem := blockingQueue.GetWait()
-
-					resultMutex.Lock()
-
-					result = append(result, elem)
-					resultMutex.Unlock()
-
-					defer wg.Done()
-				}()
-			}
-
-			wg.Wait()
-
-			sort.SliceStable(result, func(i, j int) bool {
-				return result[i] < result[j]
-			})
-
-			if !reflect.DeepEqual(ids, result) {
-				t.Fatalf("expected result to be %v, got %v", ids, result)
-			}
-		})
-
-		t.Run("PeekWaitAndPushWaiting", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1}
-
-			blockingQueue := queue.NewBlocking(elems)
-
-			_ = blockingQueue.GetWait()
-
-			var wg sync.WaitGroup
-
-			wg.Add(2)
-
-			peekDone := make(chan struct{})
-
-			blockingQueue.Reset()
-
-			go func() {
-				defer wg.Done()
-				defer close(peekDone)
-
-				elem := blockingQueue.PeekWait()
-
-				t.Log("peek done")
-
-				if elems[0] != elem {
-					t.Errorf("expected elem to be %d, got %d", elems[0], elem)
-				}
-			}()
-
-			go func() {
-				defer wg.Done()
-
-				<-peekDone
-
-				elem := blockingQueue.GetWait()
-				if elems[0] != elem {
-					t.Errorf("expected elem to be %d, got %d", elems[0], elem)
-				}
-			}()
-
-			wg.Wait()
-		})
-
-		t.Run("ResetWhileMoreRoutinesThanElementsAreWaiting", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2, 3}
-
-			const noRoutines = 100
-
-			for i := 1; i <= noRoutines; i++ {
-				t.Run(
-					fmt.Sprintf("%dRoutinesWaiting", i),
-					func(t *testing.T) {
-						testResetOnMultipleRoutinesFunc[int](elems, i)(t)
-					},
-				)
-			}
-		})
-	})
-
-	t.Run("Clear", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2, 3}
-
-			blockingQueue := queue.NewBlocking(elems)
-
-			queueElems := blockingQueue.Clear()
-
-			if !reflect.DeepEqual(elems, queueElems) {
-				t.Fatalf("expected elements to be %v, got %v", elems, queueElems)
-			}
-		})
-
-		t.Run("Empty", func(t *testing.T) {
-			t.Parallel()
-
-			blockingQueue := queue.NewBlocking([]int{})
-
-			queueElems := blockingQueue.Clear()
-
-			if len(queueElems) != 0 {
-				t.Fatalf("expected elements to be empty, got %v", queueElems)
-			}
-		})
-	})
-
-	t.Run("Contains", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("True", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2, 3}
-
-			blockingQueue := queue.NewBlocking(elems)
-
-			if !blockingQueue.Contains(2) {
-				t.Fatal("expected queue to contain 2")
-			}
-		})
-
-		t.Run("False", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2, 3}
-
-			blockingQueue := queue.NewBlocking(elems)
-
-			if blockingQueue.Contains(4) {
-				t.Fatal("expected queue to not contain 4")
-			}
-		})
-	})
-
-	t.Run("Iterator", func(t *testing.T) {
+	t.Run("SequentialIteration", func(t *testing.T) {
 		t.Parallel()
 
 		elems := []int{1, 2, 3}
 
 		blockingQueue := queue.NewBlocking(elems)
 
-		iterCh := blockingQueue.Iterator()
+		for j := range elems {
+			elem := blockingQueue.GetWait()
+
+			if elems[j] != elem {
+				t.Fatalf("expected elem to be %d, got %d", elems[j], elem)
+			}
+		}
+	})
+
+	t.Run("100ConcurrentGoroutinesReading", func(t *testing.T) {
+		t.Parallel()
+
+		const lenElements = 100
+
+		ids := make([]int, lenElements)
+
+		for i := 1; i <= lenElements; i++ {
+			ids[i-1] = i
+		}
+
+		blockingQueue := queue.NewBlocking(ids)
+
+		var (
+			wg          sync.WaitGroup
+			resultMutex sync.Mutex
+		)
+
+		wg.Add(lenElements)
+
+		result := make([]int, 0, lenElements)
+
+		for i := 0; i < lenElements; i++ {
+			go func() {
+				elem := blockingQueue.GetWait()
+
+				resultMutex.Lock()
+
+				result = append(result, elem)
+				resultMutex.Unlock()
+
+				defer wg.Done()
+			}()
+		}
+
+		wg.Wait()
+
+		sort.SliceStable(result, func(i, j int) bool {
+			return result[i] < result[j]
+		})
+
+		if !reflect.DeepEqual(ids, result) {
+			t.Fatalf("expected result to be %v, got %v", ids, result)
+		}
+	})
+
+	t.Run("PeekWaitAndPushWaiting", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{1}
+
+		blockingQueue := queue.NewBlocking(elems)
+
+		_ = blockingQueue.GetWait()
+
+		var wg sync.WaitGroup
+
+		wg.Add(2)
+
+		peekDone := make(chan struct{})
+
+		blockingQueue.Reset()
+
+		go func() {
+			defer wg.Done()
+			defer close(peekDone)
+
+			elem := blockingQueue.PeekWait()
+
+			t.Log("peek done")
+
+			if elems[0] != elem {
+				t.Errorf("expected elem to be %d, got %d", elems[0], elem)
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			<-peekDone
+
+			elem := blockingQueue.GetWait()
+			if elems[0] != elem {
+				t.Errorf("expected elem to be %d, got %d", elems[0], elem)
+			}
+		}()
+
+		wg.Wait()
+	})
+
+	t.Run("ResetWhileMoreRoutinesThanElementsAreWaiting", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{1, 2, 3}
+
+		const noRoutines = 100
+
+		for i := 1; i <= noRoutines; i++ {
+			t.Run(
+				fmt.Sprintf("%dRoutinesWaiting", i),
+				func(t *testing.T) {
+					testResetOnMultipleRoutinesFunc[int](elems, i)(t)
+				},
+			)
+		}
+	})
+}
+
+func testBlockingClear(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{1, 2, 3}
+
+		blockingQueue := queue.NewBlocking(elems)
+
+		queueElems := blockingQueue.Clear()
+
+		if !reflect.DeepEqual(elems, queueElems) {
+			t.Fatalf("expected elements to be %v, got %v", elems, queueElems)
+		}
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+
+		blockingQueue := queue.NewBlocking([]int{})
+
+		queueElems := blockingQueue.Clear()
+
+		if len(queueElems) != 0 {
+			t.Fatalf("expected elements to be empty, got %v", queueElems)
+		}
+	})
+}
+
+func testBlockingContains(t *testing.T) {
+	t.Parallel()
+
+	t.Run("True", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{1, 2, 3}
+
+		blockingQueue := queue.NewBlocking(elems)
+
+		if !blockingQueue.Contains(2) {
+			t.Fatal("expected queue to contain 2")
+		}
+	})
+
+	t.Run("False", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{1, 2, 3}
+
+		blockingQueue := queue.NewBlocking(elems)
+
+		if blockingQueue.Contains(4) {
+			t.Fatal("expected queue to not contain 4")
+		}
+	})
+}
+
+func testBlockingIterator(t *testing.T) {
+	t.Parallel()
+
+	elems := []int{1, 2, 3}
+
+	blockingQueue := queue.NewBlocking(elems)
+
+	iterCh := blockingQueue.Iterator()
+
+	if !blockingQueue.IsEmpty() {
+		t.Fatal("expected queue to be empty")
+	}
+
+	iterElems := make([]int, 0, len(elems))
+
+	for e := range iterCh {
+		iterElems = append(iterElems, e)
+	}
+
+	if !reflect.DeepEqual(elems, iterElems) {
+		t.Fatalf("expected elements to be %v, got %v", elems, iterElems)
+	}
+}
+
+func testBlockingIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	t.Run("True", func(t *testing.T) {
+		t.Parallel()
+
+		blockingQueue := queue.NewBlocking([]int{})
 
 		if !blockingQueue.IsEmpty() {
 			t.Fatal("expected queue to be empty")
 		}
+	})
 
-		iterElems := make([]int, 0, len(elems))
+	t.Run("False", func(t *testing.T) {
+		t.Parallel()
 
-		for e := range iterCh {
-			iterElems = append(iterElems, e)
+		blockingQueue := queue.NewBlocking([]int{1})
+
+		if blockingQueue.IsEmpty() {
+			t.Fatal("expected queue to not be empty")
+		}
+	})
+}
+
+func testBlockingReset(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WithCapacity", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{1, 2, 3}
+
+		initialSize := len(elems)
+
+		blockingQueue := queue.NewBlocking(
+			elems,
+			queue.WithCapacity(initialSize+1),
+		)
+
+		if blockingQueue.Size() != initialSize {
+			t.Fatalf("expected size to be %d, got %d", initialSize, blockingQueue.Size())
 		}
 
-		if !reflect.DeepEqual(elems, iterElems) {
-			t.Fatalf("expected elements to be %v, got %v", elems, iterElems)
+		blockingQueue.OfferWait(4)
+
+		if blockingQueue.Size() != initialSize+1 {
+			t.Fatalf("expected size to be %d, got %d", initialSize+1, blockingQueue.Size())
+		}
+
+		blockingQueue.Reset()
+
+		if blockingQueue.Size() != initialSize {
+			t.Fatalf("expected size to be %d, got %d", initialSize, blockingQueue.Size())
+		}
+
+		_ = blockingQueue.Clear()
+
+		elem := make(chan int)
+
+		go func() {
+			elem <- blockingQueue.GetWait()
+		}()
+
+		blockingQueue.OfferWait(5)
+
+		if e := <-elem; e != 5 {
+			t.Fatalf("expected elem to be %d, got %d", 5, e)
 		}
 	})
+}
 
-	t.Run("IsEmpty", func(t *testing.T) {
-		t.Parallel()
+func testBlockingOfferWait(t *testing.T) {
+	t.Parallel()
 
-		t.Run("True", func(t *testing.T) {
-			t.Parallel()
-
-			blockingQueue := queue.NewBlocking([]int{})
-
-			if !blockingQueue.IsEmpty() {
-				t.Fatal("expected queue to be empty")
-			}
-		})
-
-		t.Run("False", func(t *testing.T) {
-			t.Parallel()
-
-			blockingQueue := queue.NewBlocking([]int{1})
-
-			if blockingQueue.IsEmpty() {
-				t.Fatal("expected queue to not be empty")
-			}
-		})
-	})
-
-	t.Run("Reset", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("WithCapacity", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2, 3}
-
-			initialSize := len(elems)
-
-			blockingQueue := queue.NewBlocking(
-				elems,
-				queue.WithCapacity(initialSize+1),
-			)
-
-			if blockingQueue.Size() != initialSize {
-				t.Fatalf("expected size to be %d, got %d", initialSize, blockingQueue.Size())
-			}
-
-			blockingQueue.OfferWait(4)
-
-			if blockingQueue.Size() != initialSize+1 {
-				t.Fatalf("expected size to be %d, got %d", initialSize+1, blockingQueue.Size())
-			}
-
-			blockingQueue.Reset()
-
-			if blockingQueue.Size() != initialSize {
-				t.Fatalf("expected size to be %d, got %d", initialSize, blockingQueue.Size())
-			}
-
-			_ = blockingQueue.Clear()
-
-			elem := make(chan int)
-
-			go func() {
-				elem <- blockingQueue.GetWait()
-			}()
-
-			blockingQueue.OfferWait(5)
-
-			if e := <-elem; e != 5 {
-				t.Fatalf("expected elem to be %d, got %d", 5, e)
-			}
-		})
-	})
-
-	t.Run("OfferWait", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("NoCapacity", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2, 3}
-
-			blockingQueue := queue.NewBlocking(elems)
-
-			_ = blockingQueue.Clear()
-
-			elem := make(chan int)
-
-			go func() {
-				elem <- blockingQueue.GetWait()
-			}()
-
-			blockingQueue.OfferWait(4)
-
-			if e := <-elem; e != 4 {
-				t.Fatalf("expected elem to be %d, got %d", 4, e)
-			}
-		})
-
-		t.Run("WithCapacity", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2, 3}
-
-			blockingQueue := queue.NewBlocking(
-				elems,
-				queue.WithCapacity(len(elems)),
-			)
-
-			added := make(chan struct{})
-
-			go func() {
-				defer close(added)
-
-				blockingQueue.OfferWait(4)
-			}()
-
-			select {
-			case <-added:
-				t.Fatal("received unexpected signal")
-			case <-time.After(time.Millisecond):
-			}
-
-			for range elems {
-				blockingQueue.GetWait()
-			}
-
-			if e := blockingQueue.GetWait(); e != 4 {
-				t.Fatalf("expected elem to be %d, got %d", 4, e)
-			}
-		})
-	})
-
-	t.Run("Offer", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("NoCapacity", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2, 3}
-
-			blockingQueue := queue.NewBlocking[int](elems)
-
-			_ = blockingQueue.Clear()
-
-			elem := make(chan int)
-
-			go func() {
-				elem <- blockingQueue.GetWait()
-			}()
-
-			if err := blockingQueue.Offer(4); err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			if e := <-elem; e != 4 {
-				t.Fatalf("expected elem to be %d, got %d", 4, e)
-			}
-		})
-
-		t.Run("WithCapacity", func(t *testing.T) {
-			t.Run("Success", func(t *testing.T) {
-				t.Parallel()
-
-				elems := []int{1, 2, 3}
-
-				blockingQueue := queue.NewBlocking(
-					elems,
-					queue.WithCapacity(len(elems)),
-				)
-
-				if _, err := blockingQueue.Get(); err != nil {
-					t.Fatalf("expected no error, got %v", err)
-				}
-
-				if err := blockingQueue.Offer(4); err != nil {
-					t.Fatalf("expected no error, got %v", err)
-				}
-
-				if e := blockingQueue.GetWait(); e != 2 {
-					t.Fatalf("expected elem to be %d, got %d", 2, e)
-				}
-			})
-
-			t.Run("ErrQueueIsFull", func(t *testing.T) {
-				t.Parallel()
-
-				elems := []int{1, 2, 3}
-
-				blockingQueue := queue.NewBlocking(
-					elems,
-					queue.WithCapacity(len(elems)),
-				)
-
-				if err := blockingQueue.Offer(4); !errors.Is(err, queue.ErrQueueIsFull) {
-					t.Fatalf("expected error to be %v, got %v", queue.ErrQueueIsFull, err)
-				}
-			})
-		})
-	})
-
-	t.Run("Peek", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2, 3}
-
-			blockingQueue := queue.NewBlocking(elems)
-
-			elem, err := blockingQueue.Peek()
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			if elem != 1 {
-				t.Fatalf("expected elem to be %d, got %d", 1, elem)
-			}
-		})
-
-		t.Run("ErrNoElementsAvailable", func(t *testing.T) {
-			t.Parallel()
-
-			blockingQueue := queue.NewBlocking([]int{})
-
-			if _, err := blockingQueue.Peek(); !errors.Is(err, queue.ErrNoElementsAvailable) {
-				t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
-			}
-		})
-	})
-
-	t.Run("PeekWait", func(t *testing.T) {
+	t.Run("NoCapacity", func(t *testing.T) {
 		t.Parallel()
 
 		elems := []int{1, 2, 3}
@@ -467,300 +328,458 @@ func TestBlocking(t *testing.T) {
 		elem := make(chan int)
 
 		go func() {
-			elem <- blockingQueue.PeekWait()
+			elem <- blockingQueue.GetWait()
 		}()
-
-		time.Sleep(time.Millisecond)
 
 		blockingQueue.OfferWait(4)
 
 		if e := <-elem; e != 4 {
 			t.Fatalf("expected elem to be %d, got %d", 4, e)
 		}
-
-		if e := blockingQueue.GetWait(); e != 4 {
-			t.Fatalf("expected elem to be %d, got %d", 4, e)
-		}
-	})
-
-	t.Run("Get", func(t *testing.T) {
-		t.Parallel()
-
-		elems := []int{1, 2, 3}
-
-		t.Run("ErrNoElementsAvailable", func(t *testing.T) {
-			t.Parallel()
-
-			blockingQueue := queue.NewBlocking(elems)
-
-			for range elems {
-				blockingQueue.GetWait()
-			}
-
-			if _, err := blockingQueue.Get(); !errors.Is(err, queue.ErrNoElementsAvailable) {
-				t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
-			}
-		})
-
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
-
-			blockingQueue := queue.NewBlocking(elems)
-
-			elem, err := blockingQueue.Get()
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			if elem != 1 {
-				t.Fatalf("expected elem to be %d, got %d", 1, elem)
-			}
-		})
 	})
 
 	t.Run("WithCapacity", func(t *testing.T) {
 		t.Parallel()
 
 		elems := []int{1, 2, 3}
-		capacity := 2
 
-		blocking := queue.NewBlocking(elems, queue.WithCapacity(capacity))
+		blockingQueue := queue.NewBlocking(
+			elems,
+			queue.WithCapacity(len(elems)),
+		)
 
-		if blocking.Size() != capacity {
-			t.Fatalf("expected size to be %d, got %d", capacity, blocking.Size())
+		added := make(chan struct{})
+
+		go func() {
+			defer close(added)
+
+			blockingQueue.OfferWait(4)
+		}()
+
+		select {
+		case <-added:
+			t.Fatal("received unexpected signal")
+		case <-time.After(time.Millisecond):
 		}
 
-		if e := blocking.GetWait(); e != 1 {
-			t.Fatalf("expected elem to be %d, got %d", 1, e)
+		for range elems {
+			blockingQueue.GetWait()
 		}
 
-		if e := blocking.GetWait(); e != 2 {
-			t.Fatalf("expected elem to be %d, got %d", 2, e)
+		if e := blockingQueue.GetWait(); e != 4 {
+			t.Fatalf("expected elem to be %d, got %d", 4, e)
 		}
+	})
+}
+
+func testBlockingOffer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NoCapacity", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{1, 2, 3}
+
+		blockingQueue := queue.NewBlocking[int](elems)
+
+		_ = blockingQueue.Clear()
 
 		elem := make(chan int)
 
 		go func() {
-			elem <- blocking.GetWait()
+			elem <- blockingQueue.GetWait()
 		}()
 
-		select {
-		case e := <-elem:
-			t.Fatalf("received unexepected elem: %d", e)
-		case <-time.After(time.Microsecond):
+		if err := blockingQueue.Offer(4); err != nil {
+			t.Fatalf("expected no error, got %v", err)
 		}
-
-		blocking.OfferWait(4)
 
 		if e := <-elem; e != 4 {
 			t.Fatalf("expected elem to be %d, got %d", 4, e)
 		}
 	})
 
-	t.Run("CondWaitWithCapacity", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("OfferWait", func(t *testing.T) {
+	t.Run("WithCapacity", func(t *testing.T) {
+		t.Run("Success", func(t *testing.T) {
 			t.Parallel()
 
 			elems := []int{1, 2, 3}
-			initialSize := len(elems)
 
 			blockingQueue := queue.NewBlocking(
 				elems,
-				queue.WithCapacity(initialSize),
+				queue.WithCapacity(len(elems)),
 			)
 
-			added := make(chan struct{}, initialSize+1)
-
-			for i := 1; i <= initialSize+1; i++ {
-				go func(i int) {
-					blockingQueue.OfferWait(i)
-
-					added <- struct{}{}
-				}(i)
+			if _, err := blockingQueue.Get(); err != nil {
+				t.Fatalf("expected no error, got %v", err)
 			}
 
-			time.Sleep(time.Millisecond)
-
-			_ = blockingQueue.Clear()
-
-			// one groutine block, and three are added
-			for i := 1; i <= initialSize; i++ {
-				<-added
+			if err := blockingQueue.Offer(4); err != nil {
+				t.Fatalf("expected no error, got %v", err)
 			}
 
-			time.Sleep(time.Millisecond)
-
-			if blockingQueue.Size() != initialSize {
-				t.Fatalf("expected size to be %d, got %d", initialSize, blockingQueue.Size())
-			}
-
-			_ = blockingQueue.GetWait()
-
-			time.Sleep(time.Millisecond)
-
-			if blockingQueue.Size() != initialSize {
-				t.Fatalf("expected size to be %d, got %d", initialSize, blockingQueue.Size())
+			if e := blockingQueue.GetWait(); e != 2 {
+				t.Fatalf("expected elem to be %d, got %d", 2, e)
 			}
 		})
 
-		t.Run("GetWait", func(t *testing.T) {
+		t.Run("ErrQueueIsFull", func(t *testing.T) {
 			t.Parallel()
 
 			elems := []int{1, 2, 3}
-			initialSize := len(elems)
 
 			blockingQueue := queue.NewBlocking(
 				elems,
-				queue.WithCapacity(initialSize),
+				queue.WithCapacity(len(elems)),
 			)
 
-			for i := 1; i <= initialSize; i++ {
-				_ = blockingQueue.GetWait()
-			}
-
-			if blockingQueue.Size() != 0 {
-				t.Fatalf("expected size to be %d, got %d", 0, blockingQueue.Size())
-			}
-
-			retrievedElem := make(chan int, initialSize+1)
-
-			for i := 1; i <= initialSize+1; i++ {
-				go func() {
-					retrievedElem <- blockingQueue.GetWait()
-				}()
-			}
-
-			time.Sleep(time.Millisecond)
-			blockingQueue.Reset()
-
-			// one groutine block, and three are retrieved
-			for i := 1; i <= initialSize; i++ {
-				<-retrievedElem
-			}
-
-			if blockingQueue.Size() != 0 {
-				t.Fatalf("expected size to be %d, got %d", initialSize, blockingQueue.Size())
-			}
-
-			blockingQueue.OfferWait(4)
-
-			if e := <-retrievedElem; e != 4 {
-				t.Fatalf("expected elem to be %d, got %d", 4, e)
-			}
-		})
-
-		t.Run("PeekWait", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1}
-			initialSize := len(elems)
-
-			blockingQueue := queue.NewBlocking(
-				elems,
-				queue.WithCapacity(initialSize),
-			)
-
-			for i := 1; i <= initialSize; i++ {
-				_ = blockingQueue.GetWait()
-			}
-
-			if blockingQueue.Size() != 0 {
-				t.Fatalf("expected size to be %d, got %d", 0, blockingQueue.Size())
-			}
-
-			getCh := make(chan int, 1)
-
-			go func() {
-				getCh <- blockingQueue.GetWait()
-			}()
-
-			peekCh := make(chan int, 1)
-
-			go func() {
-				peekCh <- blockingQueue.PeekWait()
-			}()
-
-			time.Sleep(time.Millisecond)
-			blockingQueue.Reset()
-			// If GetWait is called before PeekWait, PeekWait will block
-			// If PeekWait is called before GetWait, PeekWait will not block
-			select {
-			case <-getCh:
-				select {
-				case <-peekCh:
-				case <-time.After(time.Millisecond):
-					t.Log("GetWait is called before PeekWait")
-				}
-			case <-peekCh:
-				select {
-				case <-getCh:
-					t.Log("PeekWait is called before GetWait")
-				case <-time.After(time.Millisecond):
-					t.Fatal("expected GetWait to not block")
-				}
-			case <-time.After(time.Millisecond):
-				t.Fatal("expected GetWait or PeekWait not block")
-			}
-
-			if blockingQueue.Size() != 0 {
-				t.Fatalf("expected size to be %d, got %d", 0, blockingQueue.Size())
+			if err := blockingQueue.Offer(4); !errors.Is(err, queue.ErrQueueIsFull) {
+				t.Fatalf("expected error to be %v, got %v", queue.ErrQueueIsFull, err)
 			}
 		})
 	})
+}
 
-	t.Run("MarshalJSON", func(t *testing.T) {
+func testBlockingPeek(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("HasElements", func(t *testing.T) {
-			t.Parallel()
+		elems := []int{1, 2, 3}
 
-			elems := []int{3, 2, 1}
+		blockingQueue := queue.NewBlocking(elems)
 
-			q := queue.NewBlocking(elems)
+		elem, err := blockingQueue.Peek()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
 
-			marshaled, err := json.Marshal(q)
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
+		if elem != 1 {
+			t.Fatalf("expected elem to be %d, got %d", 1, elem)
+		}
+	})
 
-			expectedMarshaled := []byte(`[3,2,1]`)
-			if !bytes.Equal(expectedMarshaled, marshaled) {
-				t.Fatalf("expected marshaled to be %s, got %s", expectedMarshaled, marshaled)
-			}
-		})
+	t.Run("ErrNoElementsAvailable", func(t *testing.T) {
+		t.Parallel()
 
-		t.Run("FailMarshal", func(t *testing.T) {
-			t.Parallel()
+		blockingQueue := queue.NewBlocking([]int{})
 
-			q := queue.NewBlocking([]failMarshal{{}})
+		if _, err := blockingQueue.Peek(); !errors.Is(err, queue.ErrNoElementsAvailable) {
+			t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
+		}
+	})
+}
 
-			marshaled, err := json.Marshal(q)
-			if err == nil {
-				t.Fatal("expected error, got nil")
-			}
+func testBlockingPeekWait(t *testing.T) {
+	t.Parallel()
 
-			if marshaled != nil {
-				t.Fatalf("expected marshaled to be nil, got %s", marshaled)
-			}
-		})
+	elems := []int{1, 2, 3}
 
-		t.Run("Empty", func(t *testing.T) {
-			t.Parallel()
+	blockingQueue := queue.NewBlocking(elems)
 
-			q := queue.NewBlocking[int](nil)
+	_ = blockingQueue.Clear()
 
-			marshaled, err := json.Marshal(q)
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
+	elem := make(chan int)
 
-			expectedMarshaled := []byte(`[]`)
-			if !bytes.Equal(expectedMarshaled, marshaled) {
-				t.Fatalf("expected marshaled to be %s, got %s", expectedMarshaled, marshaled)
-			}
-		})
+	go func() {
+		elem <- blockingQueue.PeekWait()
+	}()
+
+	time.Sleep(time.Millisecond)
+
+	blockingQueue.OfferWait(4)
+
+	if e := <-elem; e != 4 {
+		t.Fatalf("expected elem to be %d, got %d", 4, e)
+	}
+
+	if e := blockingQueue.GetWait(); e != 4 {
+		t.Fatalf("expected elem to be %d, got %d", 4, e)
+	}
+}
+
+func testBlockingGet(t *testing.T) {
+	t.Parallel()
+
+	elems := []int{1, 2, 3}
+
+	t.Run("ErrNoElementsAvailable", func(t *testing.T) {
+		t.Parallel()
+
+		blockingQueue := queue.NewBlocking(elems)
+
+		for range elems {
+			blockingQueue.GetWait()
+		}
+
+		if _, err := blockingQueue.Get(); !errors.Is(err, queue.ErrNoElementsAvailable) {
+			t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
+		}
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		blockingQueue := queue.NewBlocking(elems)
+
+		elem, err := blockingQueue.Get()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if elem != 1 {
+			t.Fatalf("expected elem to be %d, got %d", 1, elem)
+		}
+	})
+}
+
+func testBlockingWithCapacity(t *testing.T) {
+	t.Parallel()
+
+	elems := []int{1, 2, 3}
+	capacity := 2
+
+	blocking := queue.NewBlocking(elems, queue.WithCapacity(capacity))
+
+	if blocking.Size() != capacity {
+		t.Fatalf("expected size to be %d, got %d", capacity, blocking.Size())
+	}
+
+	if e := blocking.GetWait(); e != 1 {
+		t.Fatalf("expected elem to be %d, got %d", 1, e)
+	}
+
+	if e := blocking.GetWait(); e != 2 {
+		t.Fatalf("expected elem to be %d, got %d", 2, e)
+	}
+
+	elem := make(chan int)
+
+	go func() {
+		elem <- blocking.GetWait()
+	}()
+
+	select {
+	case e := <-elem:
+		t.Fatalf("received unexepected elem: %d", e)
+	case <-time.After(time.Microsecond):
+	}
+
+	blocking.OfferWait(4)
+
+	if e := <-elem; e != 4 {
+		t.Fatalf("expected elem to be %d, got %d", 4, e)
+	}
+}
+
+func testBlockingCondWaitWithCapacity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("OfferWait", testBlockingCondWaitOfferWait)
+	t.Run("GetWait", testBlockingCondWaitGetWait)
+	t.Run("PeekWait", testBlockingCondWaitPeekWait)
+}
+
+func testBlockingCondWaitOfferWait(t *testing.T) {
+	t.Parallel()
+
+	elems := []int{1, 2, 3}
+	initialSize := len(elems)
+
+	blockingQueue := queue.NewBlocking(
+		elems,
+		queue.WithCapacity(initialSize),
+	)
+
+	added := make(chan struct{}, initialSize+1)
+
+	for i := 1; i <= initialSize+1; i++ {
+		go func(i int) {
+			blockingQueue.OfferWait(i)
+
+			added <- struct{}{}
+		}(i)
+	}
+
+	time.Sleep(time.Millisecond)
+
+	_ = blockingQueue.Clear()
+
+	// one groutine block, and three are added
+	for i := 1; i <= initialSize; i++ {
+		<-added
+	}
+
+	time.Sleep(time.Millisecond)
+
+	if blockingQueue.Size() != initialSize {
+		t.Fatalf("expected size to be %d, got %d", initialSize, blockingQueue.Size())
+	}
+
+	_ = blockingQueue.GetWait()
+
+	time.Sleep(time.Millisecond)
+
+	if blockingQueue.Size() != initialSize {
+		t.Fatalf("expected size to be %d, got %d", initialSize, blockingQueue.Size())
+	}
+}
+
+func testBlockingCondWaitGetWait(t *testing.T) {
+	t.Parallel()
+
+	elems := []int{1, 2, 3}
+	initialSize := len(elems)
+
+	blockingQueue := queue.NewBlocking(
+		elems,
+		queue.WithCapacity(initialSize),
+	)
+
+	for i := 1; i <= initialSize; i++ {
+		_ = blockingQueue.GetWait()
+	}
+
+	if blockingQueue.Size() != 0 {
+		t.Fatalf("expected size to be %d, got %d", 0, blockingQueue.Size())
+	}
+
+	retrievedElem := make(chan int, initialSize+1)
+
+	for i := 1; i <= initialSize+1; i++ {
+		go func() {
+			retrievedElem <- blockingQueue.GetWait()
+		}()
+	}
+
+	time.Sleep(time.Millisecond)
+	blockingQueue.Reset()
+
+	// one groutine block, and three are retrieved
+	for i := 1; i <= initialSize; i++ {
+		<-retrievedElem
+	}
+
+	if blockingQueue.Size() != 0 {
+		t.Fatalf("expected size to be %d, got %d", initialSize, blockingQueue.Size())
+	}
+
+	blockingQueue.OfferWait(4)
+
+	if e := <-retrievedElem; e != 4 {
+		t.Fatalf("expected elem to be %d, got %d", 4, e)
+	}
+}
+
+func testBlockingCondWaitPeekWait(t *testing.T) {
+	t.Parallel()
+
+	elems := []int{1}
+	initialSize := len(elems)
+
+	blockingQueue := queue.NewBlocking(
+		elems,
+		queue.WithCapacity(initialSize),
+	)
+
+	for i := 1; i <= initialSize; i++ {
+		_ = blockingQueue.GetWait()
+	}
+
+	if blockingQueue.Size() != 0 {
+		t.Fatalf("expected size to be %d, got %d", 0, blockingQueue.Size())
+	}
+
+	getCh := make(chan int, 1)
+
+	go func() {
+		getCh <- blockingQueue.GetWait()
+	}()
+
+	peekCh := make(chan int, 1)
+
+	go func() {
+		peekCh <- blockingQueue.PeekWait()
+	}()
+
+	time.Sleep(time.Millisecond)
+	blockingQueue.Reset()
+	// If GetWait is called before PeekWait, PeekWait will block
+	// If PeekWait is called before GetWait, PeekWait will not block
+	select {
+	case <-getCh:
+		select {
+		case <-peekCh:
+		case <-time.After(time.Millisecond):
+			t.Log("GetWait is called before PeekWait")
+		}
+	case <-peekCh:
+		select {
+		case <-getCh:
+			t.Log("PeekWait is called before GetWait")
+		case <-time.After(time.Millisecond):
+			t.Fatal("expected GetWait to not block")
+		}
+	case <-time.After(time.Millisecond):
+		t.Fatal("expected GetWait or PeekWait not block")
+	}
+
+	if blockingQueue.Size() != 0 {
+		t.Fatalf("expected size to be %d, got %d", 0, blockingQueue.Size())
+	}
+}
+
+func testBlockingMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HasElements", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{3, 2, 1}
+
+		q := queue.NewBlocking(elems)
+
+		marshaled, err := json.Marshal(q)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		expectedMarshaled := []byte(`[3,2,1]`)
+		if !bytes.Equal(expectedMarshaled, marshaled) {
+			t.Fatalf("expected marshaled to be %s, got %s", expectedMarshaled, marshaled)
+		}
+	})
+
+	t.Run("FailMarshal", func(t *testing.T) {
+		t.Parallel()
+
+		q := queue.NewBlocking([]failMarshal{{}})
+
+		marshaled, err := json.Marshal(q)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+
+		if marshaled != nil {
+			t.Fatalf("expected marshaled to be nil, got %s", marshaled)
+		}
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+
+		q := queue.NewBlocking[int](nil)
+
+		marshaled, err := json.Marshal(q)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		expectedMarshaled := []byte(`[]`)
+		if !bytes.Equal(expectedMarshaled, marshaled) {
+			t.Fatalf("expected marshaled to be %s, got %s", expectedMarshaled, marshaled)
+		}
 	})
 }
 

--- a/blocking_test.go
+++ b/blocking_test.go
@@ -63,6 +63,7 @@ func TestBlocking(t *testing.T) {
 					elem := blockingQueue.GetWait()
 
 					resultMutex.Lock()
+
 					result = append(result, elem)
 					resultMutex.Unlock()
 
@@ -104,7 +105,7 @@ func TestBlocking(t *testing.T) {
 
 				elem := blockingQueue.PeekWait()
 
-				t.Logf("peek done")
+				t.Log("peek done")
 
 				if elems[0] != elem {
 					t.Errorf("expected elem to be %d, got %d", elems[0], elem)
@@ -113,6 +114,7 @@ func TestBlocking(t *testing.T) {
 
 			go func() {
 				defer wg.Done()
+
 				<-peekDone
 
 				elem := blockingQueue.GetWait()
@@ -132,8 +134,6 @@ func TestBlocking(t *testing.T) {
 			const noRoutines = 100
 
 			for i := 1; i <= noRoutines; i++ {
-				i := i
-
 				t.Run(
 					fmt.Sprintf("%dRoutinesWaiting", i),
 					func(t *testing.T) {
@@ -185,7 +185,7 @@ func TestBlocking(t *testing.T) {
 			blockingQueue := queue.NewBlocking(elems)
 
 			if !blockingQueue.Contains(2) {
-				t.Fatalf("expected queue to contain 2")
+				t.Fatal("expected queue to contain 2")
 			}
 		})
 
@@ -197,7 +197,7 @@ func TestBlocking(t *testing.T) {
 			blockingQueue := queue.NewBlocking(elems)
 
 			if blockingQueue.Contains(4) {
-				t.Fatalf("expected queue to not contain 4")
+				t.Fatal("expected queue to not contain 4")
 			}
 		})
 	})
@@ -212,7 +212,7 @@ func TestBlocking(t *testing.T) {
 		iterCh := blockingQueue.Iterator()
 
 		if !blockingQueue.IsEmpty() {
-			t.Fatalf("expected queue to be empty")
+			t.Fatal("expected queue to be empty")
 		}
 
 		iterElems := make([]int, 0, len(elems))
@@ -235,7 +235,7 @@ func TestBlocking(t *testing.T) {
 			blockingQueue := queue.NewBlocking([]int{})
 
 			if !blockingQueue.IsEmpty() {
-				t.Fatalf("expected queue to be empty")
+				t.Fatal("expected queue to be empty")
 			}
 		})
 
@@ -245,7 +245,7 @@ func TestBlocking(t *testing.T) {
 			blockingQueue := queue.NewBlocking([]int{1})
 
 			if blockingQueue.IsEmpty() {
-				t.Fatalf("expected queue to not be empty")
+				t.Fatal("expected queue to not be empty")
 			}
 		})
 	})
@@ -342,7 +342,7 @@ func TestBlocking(t *testing.T) {
 
 			select {
 			case <-added:
-				t.Fatalf("received unexpected signal")
+				t.Fatal("received unexpected signal")
 			case <-time.After(time.Millisecond):
 			}
 
@@ -576,6 +576,7 @@ func TestBlocking(t *testing.T) {
 			for i := 1; i <= initialSize+1; i++ {
 				go func(i int) {
 					blockingQueue.OfferWait(i)
+
 					added <- struct{}{}
 				}(i)
 			}
@@ -670,11 +671,13 @@ func TestBlocking(t *testing.T) {
 			}
 
 			getCh := make(chan int, 1)
+
 			go func() {
 				getCh <- blockingQueue.GetWait()
 			}()
 
 			peekCh := make(chan int, 1)
+
 			go func() {
 				peekCh <- blockingQueue.PeekWait()
 			}()
@@ -688,17 +691,17 @@ func TestBlocking(t *testing.T) {
 				select {
 				case <-peekCh:
 				case <-time.After(time.Millisecond):
-					t.Logf("GetWait is called before PeekWait")
+					t.Log("GetWait is called before PeekWait")
 				}
 			case <-peekCh:
 				select {
 				case <-getCh:
-					t.Logf("PeekWait is called before GetWait")
+					t.Log("PeekWait is called before GetWait")
 				case <-time.After(time.Millisecond):
-					t.Fatalf("expected GetWait to not block")
+					t.Fatal("expected GetWait to not block")
 				}
 			case <-time.After(time.Millisecond):
-				t.Fatalf("expected GetWait or PeekWait not block")
+				t.Fatal("expected GetWait or PeekWait not block")
 			}
 
 			if blockingQueue.Size() != 0 {
@@ -735,7 +738,7 @@ func TestBlocking(t *testing.T) {
 
 			marshaled, err := json.Marshal(q)
 			if err == nil {
-				t.Fatalf("expected error, got nil")
+				t.Fatal("expected error, got nil")
 			}
 
 			if marshaled != nil {

--- a/circular.go
+++ b/circular.go
@@ -221,16 +221,37 @@ func (q *Circular[T]) get() (v T, _ error) {
 		return v, ErrNoElementsAvailable
 	}
 
+	item := q.pop()
+
+	return item, nil
+}
+
+func (q *Circular[T]) pop() (v T) {
 	item := q.elems[q.head]
+	q.elems[q.head] = *new(T) // clear popped slot for garbage collection
 	q.head = (q.head + 1) % len(q.elems)
 	q.size--
 
-	return item, nil
+	return item
 }
 
 // isEmpty returns true if the queue is empty.
 func (q *Circular[T]) isEmpty() bool {
 	return q.size == 0
+}
+
+// drainQueue collects and removes all elements from the queue.
+// It returns a slice containing all elements in their logical order.
+// Note: This method assumes the caller holds an appropriate lock.
+func (q *Circular[T]) drainQueue() []T {
+	// Preallocate the slice with the exact size
+	elems := make([]T, q.size)
+
+	for i := 0; i < q.size; i++ {
+		elems[i] = q.pop()
+	}
+
+	return elems
 }
 
 // MarshalJSON serializes the Circular queue to JSON.
@@ -243,11 +264,11 @@ func (q *Circular[T]) MarshalJSON() ([]byte, error) {
 	}
 
 	// Collect elements in logical order from head to tail.
-	elements := make([]T, 0, q.size)
+	elements := make([]T, q.size)
 
 	for i := 0; i < q.size; i++ {
 		index := (q.head + i) % len(q.elems)
-		elements = append(elements, q.elems[index])
+		elements[i] = q.elems[index]
 	}
 
 	q.lock.RUnlock()

--- a/circular.go
+++ b/circular.go
@@ -120,18 +120,8 @@ func (q *Circular[T]) Clear() []T {
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
-	elems := make([]T, 0, q.size)
+	elems := q.drainQueue()
 
-	for {
-		elem, err := q.get()
-		if err != nil {
-			break
-		}
-
-		elems = append(elems, elem)
-	}
-
-	// clear the queue
 	q.head = 0
 	q.tail = 0
 
@@ -182,7 +172,7 @@ func (q *Circular[T]) Contains(elem T) bool {
 		return false // queue is empty, item not found
 	}
 
-	for i := q.head; i < q.size; i++ {
+	for i := 0; i < q.size; i++ {
 		idx := (q.head + i) % len(q.elems)
 
 		if q.elems[idx] == elem {
@@ -244,10 +234,11 @@ func (q *Circular[T]) isEmpty() bool {
 // It returns a slice containing all elements in their logical order.
 // Note: This method assumes the caller holds an appropriate lock.
 func (q *Circular[T]) drainQueue() []T {
-	// Preallocate the slice with the exact size
-	elems := make([]T, q.size)
+	n := q.size
 
-	for i := 0; i < q.size; i++ {
+	elems := make([]T, n)
+
+	for i := 0; i < n; i++ {
 		elems[i] = q.pop()
 	}
 

--- a/circular.go
+++ b/circular.go
@@ -141,8 +141,8 @@ func (q *Circular[T]) Clear() []T {
 // Iterator returns an iterator over the elements in the queue.
 // It removes the elements from the queue.
 func (q *Circular[T]) Iterator() <-chan T {
-	q.lock.RLock()
-	defer q.lock.RUnlock()
+	q.lock.Lock()
+	defer q.lock.Unlock()
 
 	// use a buffered channel to avoid blocking the iterator.
 	iteratorCh := make(chan T, q.size)

--- a/circular_test.go
+++ b/circular_test.go
@@ -13,212 +13,199 @@ import (
 func TestCircular(t *testing.T) {
 	t.Parallel()
 
-	t.Run("CapcaityOptionsOverwritesCapacityParam", func(t *testing.T) {
+	t.Run("CapcaityOptionsOverwritesCapacityParam", testCircularCapacityOptionOverwrites)
+	t.Run("ElemsLenGreaterThanCapacity", testCircularElemsLenGreaterThanCapacity)
+	t.Run("Get", testCircularGet)
+	t.Run("Peek", testCircularPeek)
+	t.Run("Offer", testCircularOffer)
+	t.Run("Contains", testCircularContains)
+	t.Run("Clear", testCircularClear)
+	t.Run("IsEmpty", testCircularIsEmpty)
+	t.Run("Reset", testCircularReset)
+	t.Run("Iterator", testCircularIterator)
+	t.Run("MarshalJSON", testCircularMarshalJSON)
+}
+
+func testCircularCapacityOptionOverwrites(t *testing.T) {
+	t.Parallel()
+
+	circularQueue := queue.NewCircular([]int{}, 1, queue.WithCapacity(2))
+
+	circularQueue.Offer(1)
+	circularQueue.Offer(2)
+
+	if circularQueue.Size() != 2 {
+		t.Fatalf("expected size to be 2, got %d", circularQueue.Size())
+	}
+}
+
+func testCircularElemsLenGreaterThanCapacity(t *testing.T) {
+	t.Parallel()
+
+	circularQueue := queue.NewCircular([]int{1, 2}, 1)
+
+	if circularQueue.Size() != 1 {
+		t.Fatalf("expected size to be 1, got %d", circularQueue.Size())
+	}
+}
+
+func testCircularGet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 
-		circularQueue := queue.NewCircular([]int{}, 1, queue.WithCapacity(2))
+		elems := []int{4, 1, 2}
 
-		circularQueue.Offer(1)
-		circularQueue.Offer(2)
+		circularQueue := queue.NewCircular(elems, len(elems))
+
+		elem, err := circularQueue.Get()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if elem != 4 {
+			t.Fatalf("expected elem to be 4, got %d", elem)
+		}
 
 		if circularQueue.Size() != 2 {
 			t.Fatalf("expected size to be 2, got %d", circularQueue.Size())
 		}
 	})
 
-	t.Run("ElemsLenGreaterThanCapacity", func(t *testing.T) {
+	t.Run("ErrNoElementsAvailable", func(t *testing.T) {
 		t.Parallel()
 
-		circularQueue := queue.NewCircular([]int{1, 2}, 1)
+		var elems []int
 
-		if circularQueue.Size() != 1 {
-			t.Fatalf("expected size to be 1, got %d", circularQueue.Size())
+		circularQueue := queue.NewCircular(elems, 5)
+
+		if _, err := circularQueue.Get(); !errors.Is(err, queue.ErrNoElementsAvailable) {
+			t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
+		}
+	})
+}
+
+func testCircularPeek(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{4, 1, 2}
+
+		circularQueue := queue.NewCircular(elems, len(elems))
+
+		elem, err := circularQueue.Peek()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if elem != 4 {
+			t.Fatalf("expected elem to be 4, got %d", elem)
+		}
+
+		if circularQueue.Size() != 3 {
+			t.Fatalf("expected size to be 3, got %d", circularQueue.Size())
 		}
 	})
 
-	t.Run("Get", func(t *testing.T) {
+	t.Run("ErrNoElementsAvailable", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
+		var elems []int
 
-			elems := []int{4, 1, 2}
+		circularQueue := queue.NewCircular(elems, 5)
 
-			circularQueue := queue.NewCircular(elems, len(elems))
+		if _, err := circularQueue.Peek(); !errors.Is(err, queue.ErrNoElementsAvailable) {
+			t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
+		}
+	})
+}
 
-			elem, err := circularQueue.Get()
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
+func testCircularOffer(t *testing.T) {
+	t.Parallel()
 
-			if elem != 4 {
-				t.Fatalf("expected elem to be 4, got %d", elem)
-			}
+	t.Run("SuccessEmptyQueue", func(t *testing.T) {
+		var elems []int
 
-			if circularQueue.Size() != 2 {
-				t.Fatalf("expected size to be 2, got %d", circularQueue.Size())
-			}
-		})
+		circularQueue := queue.NewCircular(elems, 5)
 
-		t.Run("ErrNoElementsAvailable", func(t *testing.T) {
-			t.Parallel()
+		err := circularQueue.Offer(1)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
 
-			var elems []int
+		err = circularQueue.Offer(2)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
 
-			circularQueue := queue.NewCircular(elems, 5)
+		if circularQueue.Size() != 2 {
+			t.Fatalf("expected size to be 2, got %d", circularQueue.Size())
+		}
 
-			if _, err := circularQueue.Get(); !errors.Is(err, queue.ErrNoElementsAvailable) {
-				t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
-			}
-		})
+		queueElems := circularQueue.Clear()
+		expectedElems := []int{1, 2}
+
+		if !reflect.DeepEqual(expectedElems, queueElems) {
+			t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
+		}
 	})
 
-	t.Run("Peek", func(t *testing.T) {
+	t.Run("SuccessFullQueue", func(t *testing.T) {
+		elems := []int{1, 2, 3, 4}
+
+		circularQueue := queue.NewCircular(elems, 4)
+
+		err := circularQueue.Offer(5)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if circularQueue.Size() != 4 {
+			t.Fatalf("expected size to be 4, got %d", circularQueue.Size())
+		}
+
+		nextElem, err := circularQueue.Peek()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if nextElem != 5 {
+			t.Fatalf("expected next elem to be 4, got %d", nextElem)
+		}
+
+		err = circularQueue.Offer(6)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		queueElems := circularQueue.Clear()
+		expectedElems := []int{5, 6, 3, 4}
+
+		if !reflect.DeepEqual(expectedElems, queueElems) {
+			t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
+		}
+	})
+}
+
+func testCircularContains(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
+		elems := []int{1, 2, 3, 4}
 
-			elems := []int{4, 1, 2}
+		circularQueue := queue.NewCircular(elems, 4)
 
-			circularQueue := queue.NewCircular(elems, len(elems))
-
-			elem, err := circularQueue.Peek()
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			if elem != 4 {
-				t.Fatalf("expected elem to be 4, got %d", elem)
-			}
-
-			if circularQueue.Size() != 3 {
-				t.Fatalf("expected size to be 3, got %d", circularQueue.Size())
-			}
-		})
-
-		t.Run("ErrNoElementsAvailable", func(t *testing.T) {
-			t.Parallel()
-
-			var elems []int
-
-			circularQueue := queue.NewCircular(elems, 5)
-
-			if _, err := circularQueue.Peek(); !errors.Is(err, queue.ErrNoElementsAvailable) {
-				t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
-			}
-		})
+		if !circularQueue.Contains(2) {
+			t.Fatal("expected elem to be found")
+		}
 	})
 
-	t.Run("Offer", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("SuccessEmptyQueue", func(t *testing.T) {
-			var elems []int
-
-			circularQueue := queue.NewCircular(elems, 5)
-
-			err := circularQueue.Offer(1)
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			err = circularQueue.Offer(2)
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			if circularQueue.Size() != 2 {
-				t.Fatalf("expected size to be 2, got %d", circularQueue.Size())
-			}
-
-			queueElems := circularQueue.Clear()
-			expectedElems := []int{1, 2}
-
-			if !reflect.DeepEqual(expectedElems, queueElems) {
-				t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
-			}
-		})
-
-		t.Run("SuccessFullQueue", func(t *testing.T) {
-			elems := []int{1, 2, 3, 4}
-
-			circularQueue := queue.NewCircular(elems, 4)
-
-			err := circularQueue.Offer(5)
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			if circularQueue.Size() != 4 {
-				t.Fatalf("expected size to be 4, got %d", circularQueue.Size())
-			}
-
-			nextElem, err := circularQueue.Peek()
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			if nextElem != 5 {
-				t.Fatalf("expected next elem to be 4, got %d", nextElem)
-			}
-
-			err = circularQueue.Offer(6)
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			queueElems := circularQueue.Clear()
-			expectedElems := []int{5, 6, 3, 4}
-
-			if !reflect.DeepEqual(expectedElems, queueElems) {
-				t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
-			}
-		})
-	})
-
-	t.Run("Contains", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2, 3, 4}
-
-			circularQueue := queue.NewCircular(elems, 4)
-
-			if !circularQueue.Contains(2) {
-				t.Fatal("expected elem to be found")
-			}
-		})
-
-		t.Run("NotFoundAfterGet", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2, 3, 4}
-
-			circularQueue := queue.NewCircular(elems, 4)
-
-			_, err := circularQueue.Get()
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			if circularQueue.Contains(1) {
-				t.Fatal("expected elem to not be found")
-			}
-		})
-
-		t.Run("EmptyQueue", func(t *testing.T) {
-			circularQueue := queue.NewCircular([]int{}, 1)
-
-			if circularQueue.Contains(1) {
-				t.Fatal("expected elem to not be found")
-			}
-		})
-	})
-
-	t.Run("Clear", func(t *testing.T) {
+	t.Run("NotFoundAfterGet", func(t *testing.T) {
 		t.Parallel()
 
 		elems := []int{1, 2, 3, 4}
@@ -230,105 +217,130 @@ func TestCircular(t *testing.T) {
 			t.Fatalf("expected no error, got %v", err)
 		}
 
-		queueElems := circularQueue.Clear()
-		expectedElems := []int{2, 3, 4}
-
-		if !reflect.DeepEqual(expectedElems, queueElems) {
-			t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
+		if circularQueue.Contains(1) {
+			t.Fatal("expected elem to not be found")
 		}
 	})
 
-	t.Run("IsEmpty", func(t *testing.T) {
+	t.Run("EmptyQueue", func(t *testing.T) {
 		circularQueue := queue.NewCircular([]int{}, 1)
 
-		if !circularQueue.IsEmpty() {
-			t.Fatal("expected queue to be empty")
+		if circularQueue.Contains(1) {
+			t.Fatal("expected elem to not be found")
 		}
 	})
+}
 
-	t.Run("Reset", func(t *testing.T) {
-		elems := []int{1, 2, 3, 4}
+func testCircularClear(t *testing.T) {
+	t.Parallel()
 
-		circularQueue := queue.NewCircular(elems, 5)
+	elems := []int{1, 2, 3, 4}
 
-		err := circularQueue.Offer(5)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
+	circularQueue := queue.NewCircular(elems, 4)
 
-		err = circularQueue.Offer(6)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
+	_, err := circularQueue.Get()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 
-		circularQueue.Reset()
+	queueElems := circularQueue.Clear()
+	expectedElems := []int{2, 3, 4}
 
-		queueElems := circularQueue.Clear()
-		expectedElems := []int{1, 2, 3, 4}
+	if !reflect.DeepEqual(expectedElems, queueElems) {
+		t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
+	}
+}
 
-		if !reflect.DeepEqual(expectedElems, queueElems) {
-			t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
-		}
-	})
+func testCircularIsEmpty(t *testing.T) {
+	circularQueue := queue.NewCircular([]int{}, 1)
 
-	t.Run("Iterator", func(t *testing.T) {
-		elems := []int{1, 2, 3, 4}
+	if !circularQueue.IsEmpty() {
+		t.Fatal("expected queue to be empty")
+	}
+}
 
-		circularQueue := queue.NewCircular(elems, 5)
+func testCircularReset(t *testing.T) {
+	elems := []int{1, 2, 3, 4}
 
-		iterCh := circularQueue.Iterator()
+	circularQueue := queue.NewCircular(elems, 5)
 
-		if !circularQueue.IsEmpty() {
-			t.Fatal("expected queue to be empty")
-		}
+	err := circularQueue.Offer(5)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 
-		iterElems := make([]int, 0, len(elems))
+	err = circularQueue.Offer(6)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 
-		for e := range iterCh {
-			iterElems = append(iterElems, e)
-		}
+	circularQueue.Reset()
 
-		if !reflect.DeepEqual(elems, iterElems) {
-			t.Fatalf("expected elements to be %v, got %v", elems, iterElems)
-		}
-	})
+	queueElems := circularQueue.Clear()
+	expectedElems := []int{1, 2, 3, 4}
 
-	t.Run("MarshalJSON", func(t *testing.T) {
+	if !reflect.DeepEqual(expectedElems, queueElems) {
+		t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
+	}
+}
+
+func testCircularIterator(t *testing.T) {
+	elems := []int{1, 2, 3, 4}
+
+	circularQueue := queue.NewCircular(elems, 5)
+
+	iterCh := circularQueue.Iterator()
+
+	if !circularQueue.IsEmpty() {
+		t.Fatal("expected queue to be empty")
+	}
+
+	iterElems := make([]int, 0, len(elems))
+
+	for e := range iterCh {
+		iterElems = append(iterElems, e)
+	}
+
+	if !reflect.DeepEqual(elems, iterElems) {
+		t.Fatalf("expected elements to be %v, got %v", elems, iterElems)
+	}
+}
+
+func testCircularMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HasElements", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("HasElements", func(t *testing.T) {
-			t.Parallel()
+		elems := []int{3, 2, 1}
 
-			elems := []int{3, 2, 1}
+		q := queue.NewCircular(elems, 4)
 
-			q := queue.NewCircular(elems, 4)
+		marshaled, err := json.Marshal(q)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
 
-			marshaled, err := json.Marshal(q)
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
+		expectedMarshaled := []byte(`[3,2,1]`)
+		if !bytes.Equal(expectedMarshaled, marshaled) {
+			t.Fatalf("expected marshaled to be %s, got %s", expectedMarshaled, marshaled)
+		}
+	})
 
-			expectedMarshaled := []byte(`[3,2,1]`)
-			if !bytes.Equal(expectedMarshaled, marshaled) {
-				t.Fatalf("expected marshaled to be %s, got %s", expectedMarshaled, marshaled)
-			}
-		})
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
 
-		t.Run("Empty", func(t *testing.T) {
-			t.Parallel()
+		q := queue.NewCircular[int](nil, 1)
 
-			q := queue.NewCircular[int](nil, 1)
+		marshaled, err := json.Marshal(q)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
 
-			marshaled, err := json.Marshal(q)
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			expectedMarshaled := []byte(`[]`)
-			if !bytes.Equal(expectedMarshaled, marshaled) {
-				t.Fatalf("expected marshaled to be %s, got %s", expectedMarshaled, marshaled)
-			}
-		})
+		expectedMarshaled := []byte(`[]`)
+		if !bytes.Equal(expectedMarshaled, marshaled) {
+			t.Fatalf("expected marshaled to be %s, got %s", expectedMarshaled, marshaled)
+		}
 	})
 }
 

--- a/circular_test.go
+++ b/circular_test.go
@@ -188,7 +188,7 @@ func TestCircular(t *testing.T) {
 			circularQueue := queue.NewCircular(elems, 4)
 
 			if !circularQueue.Contains(2) {
-				t.Fatalf("expected elem to be found")
+				t.Fatal("expected elem to be found")
 			}
 		})
 
@@ -205,7 +205,7 @@ func TestCircular(t *testing.T) {
 			}
 
 			if circularQueue.Contains(1) {
-				t.Fatalf("expected elem to not be found")
+				t.Fatal("expected elem to not be found")
 			}
 		})
 
@@ -213,7 +213,7 @@ func TestCircular(t *testing.T) {
 			circularQueue := queue.NewCircular([]int{}, 1)
 
 			if circularQueue.Contains(1) {
-				t.Fatalf("expected elem to not be found")
+				t.Fatal("expected elem to not be found")
 			}
 		})
 	})
@@ -242,7 +242,7 @@ func TestCircular(t *testing.T) {
 		circularQueue := queue.NewCircular([]int{}, 1)
 
 		if !circularQueue.IsEmpty() {
-			t.Fatalf("expected queue to be empty")
+			t.Fatal("expected queue to be empty")
 		}
 	})
 
@@ -279,7 +279,7 @@ func TestCircular(t *testing.T) {
 		iterCh := circularQueue.Iterator()
 
 		if !circularQueue.IsEmpty() {
-			t.Fatalf("expected queue to be empty")
+			t.Fatal("expected queue to be empty")
 		}
 
 		iterElems := make([]int, 0, len(elems))

--- a/example_helper_test.go
+++ b/example_helper_test.go
@@ -1,0 +1,38 @@
+package queue_test
+
+import (
+	"fmt"
+
+	"github.com/adrianbrad/queue"
+)
+
+// runExampleDemo exercises a queue through a shared sequence of operations
+// used by ExampleLinked and ExamplePriority. The logical output differs per
+// implementation (e.g. clear order for priority vs. FIFO), so each Example
+// keeps its own // Output: block.
+func runExampleDemo(q queue.Queue[int]) {
+	fmt.Println("Contains 2:", q.Contains(2))
+	fmt.Println("Size:", q.Size())
+
+	if err := q.Offer(3); err != nil {
+		fmt.Println("Offer err: ", err)
+		return
+	}
+
+	fmt.Println("Empty before clear:", q.IsEmpty())
+	fmt.Println("Clear:", q.Clear())
+	fmt.Println("Empty after clear:", q.IsEmpty())
+
+	if err := q.Offer(5); err != nil {
+		fmt.Println("Offer err: ", err)
+		return
+	}
+
+	elem, err := q.Get()
+	if err != nil {
+		fmt.Println("Get err: ", err)
+		return
+	}
+
+	fmt.Println("Get:", elem)
+}

--- a/example_linked_test.go
+++ b/example_linked_test.go
@@ -1,50 +1,15 @@
 package queue_test
 
 import (
-	"fmt"
-
 	"github.com/adrianbrad/queue"
 )
 
 func ExampleLinked() {
 	elems := []int{2, 4, 1}
 
-	priorityQueue := queue.NewLinked(
-		elems,
-	)
+	linkedQueue := queue.NewLinked(elems)
 
-	containsTwo := priorityQueue.Contains(2)
-	fmt.Println("Contains 2:", containsTwo)
-
-	size := priorityQueue.Size()
-	fmt.Println("Size:", size)
-
-	if err := priorityQueue.Offer(3); err != nil {
-		fmt.Println("Offer err: ", err)
-		return
-	}
-
-	empty := priorityQueue.IsEmpty()
-	fmt.Println("Empty before clear:", empty)
-
-	clearElems := priorityQueue.Clear()
-	fmt.Println("Clear:", clearElems)
-
-	empty = priorityQueue.IsEmpty()
-	fmt.Println("Empty after clear:", empty)
-
-	if err := priorityQueue.Offer(5); err != nil {
-		fmt.Println("Offer err: ", err)
-		return
-	}
-
-	elem, err := priorityQueue.Get()
-	if err != nil {
-		fmt.Println("Get err: ", err)
-		return
-	}
-
-	fmt.Println("Get:", elem)
+	runExampleDemo(linkedQueue)
 
 	// Output:
 	// Contains 2: true

--- a/example_priority_test.go
+++ b/example_priority_test.go
@@ -1,8 +1,6 @@
 package queue_test
 
 import (
-	"fmt"
-
 	"github.com/adrianbrad/queue"
 )
 
@@ -17,38 +15,7 @@ func ExamplePriority() {
 		queue.WithCapacity(4),
 	)
 
-	containsTwo := priorityQueue.Contains(2)
-	fmt.Println("Contains 2:", containsTwo)
-
-	size := priorityQueue.Size()
-	fmt.Println("Size:", size)
-
-	if err := priorityQueue.Offer(3); err != nil {
-		fmt.Println("Offer err: ", err)
-		return
-	}
-
-	empty := priorityQueue.IsEmpty()
-	fmt.Println("Empty before clear:", empty)
-
-	clearElems := priorityQueue.Clear()
-	fmt.Println("Clear:", clearElems)
-
-	empty = priorityQueue.IsEmpty()
-	fmt.Println("Empty after clear:", empty)
-
-	if err := priorityQueue.Offer(5); err != nil {
-		fmt.Println("Offer err: ", err)
-		return
-	}
-
-	elem, err := priorityQueue.Get()
-	if err != nil {
-		fmt.Println("Get err: ", err)
-		return
-	}
-
-	fmt.Println("Get:", elem)
+	runExampleDemo(priorityQueue)
 
 	// Output:
 	// Contains 2: true

--- a/linked.go
+++ b/linked.go
@@ -154,17 +154,15 @@ func (lq *Linked[T]) isEmpty() bool {
 // Iterator returns a channel that will be filled with the elements.
 // It removes the elements from the queue.
 func (lq *Linked[T]) Iterator() <-chan T {
-	ch := make(chan T)
-
 	elems := lq.Clear()
 
-	go func() {
-		for _, e := range elems {
-			ch <- e
-		}
+	ch := make(chan T, len(elems))
 
-		close(ch)
-	}()
+	for i := range elems {
+		ch <- elems[i]
+	}
+
+	close(ch)
 
 	return ch
 }

--- a/linked.go
+++ b/linked.go
@@ -172,16 +172,14 @@ func (lq *Linked[T]) Clear() []T {
 	lq.lock.Lock()
 	defer lq.lock.Unlock()
 
-	elements := make([]T, 0, lq.size)
+	elements := make([]T, lq.size)
 
 	current := lq.head
-	for current != nil {
-		elements = append(elements, current.value)
-		next := current.next
-		current = next
+	for i := 0; current != nil; i++ {
+		elements[i] = current.value
+		current = current.next
 	}
 
-	// Clear the queue
 	lq.head = nil
 	lq.tail = nil
 	lq.size = 0
@@ -194,16 +192,13 @@ func (lq *Linked[T]) MarshalJSON() ([]byte, error) {
 	lq.lock.RLock()
 	defer lq.lock.RUnlock()
 
-	// Traverse the linked list and collect elements.
-	elements := make([]T, 0, lq.size)
+	elements := make([]T, lq.size)
 
 	current := lq.head
-
-	for current != nil {
-		elements = append(elements, current.value)
+	for i := 0; current != nil; i++ {
+		elements[i] = current.value
 		current = current.next
 	}
 
-	// Marshal the elements slice to JSON.
 	return json.Marshal(elements)
 }

--- a/linked_test.go
+++ b/linked_test.go
@@ -129,7 +129,7 @@ func TestLinked(t *testing.T) {
 			linkedQueue := queue.NewLinked(elems)
 
 			if !linkedQueue.Contains(2) {
-				t.Fatalf("expected elem to be found")
+				t.Fatal("expected elem to be found")
 			}
 		})
 
@@ -146,7 +146,7 @@ func TestLinked(t *testing.T) {
 			}
 
 			if linkedQueue.Contains(1) {
-				t.Fatalf("expected elem to not be found")
+				t.Fatal("expected elem to not be found")
 			}
 		})
 
@@ -154,7 +154,7 @@ func TestLinked(t *testing.T) {
 			linkedQueue := queue.NewLinked([]int{})
 
 			if linkedQueue.Contains(1) {
-				t.Fatalf("expected elem to not be found")
+				t.Fatal("expected elem to not be found")
 			}
 		})
 	})
@@ -183,7 +183,7 @@ func TestLinked(t *testing.T) {
 		linkedQueue := queue.NewLinked([]int{})
 
 		if !linkedQueue.IsEmpty() {
-			t.Fatalf("expected queue to be empty")
+			t.Fatal("expected queue to be empty")
 		}
 	})
 
@@ -220,7 +220,7 @@ func TestLinked(t *testing.T) {
 		iterCh := linkedQueue.Iterator()
 
 		if !linkedQueue.IsEmpty() {
-			t.Fatalf("expected queue to be empty")
+			t.Fatal("expected queue to be empty")
 		}
 
 		iterElems := make([]int, 0, len(elems))

--- a/linked_test.go
+++ b/linked_test.go
@@ -13,153 +13,138 @@ import (
 func TestLinked(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Get", func(t *testing.T) {
+	t.Run("Get", testLinkedGet)
+	t.Run("Peek", testLinkedPeek)
+	t.Run("Offer", testLinkedOffer)
+	t.Run("Contains", testLinkedContains)
+	t.Run("Clear", testLinkedClear)
+	t.Run("IsEmpty", testLinkedIsEmpty)
+	t.Run("Reset", testLinkedReset)
+	t.Run("Iterator", testLinkedIterator)
+	t.Run("MarshalJSON", testLinkedMarshalJSON)
+}
+
+func testLinkedGet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
+		elems := []int{4, 1, 2}
 
-			elems := []int{4, 1, 2}
+		linkedQueue := queue.NewLinked(elems)
 
-			linkedQueue := queue.NewLinked(elems)
+		elem, err := linkedQueue.Get()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
 
-			elem, err := linkedQueue.Get()
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
+		if elem != 4 {
+			t.Fatalf("expected elem to be 4, got %d", elem)
+		}
 
-			if elem != 4 {
-				t.Fatalf("expected elem to be 4, got %d", elem)
-			}
-
-			if linkedQueue.Size() != 2 {
-				t.Fatalf("expected size to be 2, got %d", linkedQueue.Size())
-			}
-		})
-
-		t.Run("ErrNoElementsAvailable", func(t *testing.T) {
-			t.Parallel()
-
-			var elems []int
-
-			linkedQueue := queue.NewLinked(elems)
-
-			if _, err := linkedQueue.Get(); !errors.Is(err, queue.ErrNoElementsAvailable) {
-				t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
-			}
-		})
+		if linkedQueue.Size() != 2 {
+			t.Fatalf("expected size to be 2, got %d", linkedQueue.Size())
+		}
 	})
 
-	t.Run("Peek", func(t *testing.T) {
+	t.Run("ErrNoElementsAvailable", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
+		var elems []int
 
-			elems := []int{4, 1, 2}
+		linkedQueue := queue.NewLinked(elems)
 
-			linkedQueue := queue.NewLinked(elems)
-
-			elem, err := linkedQueue.Peek()
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			if elem != 4 {
-				t.Fatalf("expected elem to be 4, got %d", elem)
-			}
-
-			if linkedQueue.Size() != 3 {
-				t.Fatalf("expected size to be 3, got %d", linkedQueue.Size())
-			}
-		})
-
-		t.Run("ErrNoElementsAvailable", func(t *testing.T) {
-			t.Parallel()
-
-			var elems []int
-
-			linkedQueue := queue.NewLinked(elems)
-
-			if _, err := linkedQueue.Peek(); !errors.Is(err, queue.ErrNoElementsAvailable) {
-				t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
-			}
-		})
+		if _, err := linkedQueue.Get(); !errors.Is(err, queue.ErrNoElementsAvailable) {
+			t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
+		}
 	})
+}
 
-	t.Run("Offer", func(t *testing.T) {
+func testLinkedPeek(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("SuccessEmptyQueue", func(t *testing.T) {
-			var elems []int
+		elems := []int{4, 1, 2}
 
-			linkedQueue := queue.NewLinked(elems)
+		linkedQueue := queue.NewLinked(elems)
 
-			err := linkedQueue.Offer(1)
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
+		elem, err := linkedQueue.Peek()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
 
-			err = linkedQueue.Offer(2)
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
+		if elem != 4 {
+			t.Fatalf("expected elem to be 4, got %d", elem)
+		}
 
-			if linkedQueue.Size() != 2 {
-				t.Fatalf("expected size to be 2, got %d", linkedQueue.Size())
-			}
-
-			queueElems := linkedQueue.Clear()
-			expectedElems := []int{1, 2}
-
-			if !reflect.DeepEqual(expectedElems, queueElems) {
-				t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
-			}
-		})
+		if linkedQueue.Size() != 3 {
+			t.Fatalf("expected size to be 3, got %d", linkedQueue.Size())
+		}
 	})
 
-	t.Run("Contains", func(t *testing.T) {
+	t.Run("ErrNoElementsAvailable", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
+		var elems []int
 
-			elems := []int{1, 2, 3, 4}
+		linkedQueue := queue.NewLinked(elems)
 
-			linkedQueue := queue.NewLinked(elems)
+		if _, err := linkedQueue.Peek(); !errors.Is(err, queue.ErrNoElementsAvailable) {
+			t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
+		}
+	})
+}
 
-			if !linkedQueue.Contains(2) {
-				t.Fatal("expected elem to be found")
-			}
-		})
+func testLinkedOffer(t *testing.T) {
+	t.Parallel()
 
-		t.Run("NotFoundAfterGet", func(t *testing.T) {
-			t.Parallel()
+	t.Run("SuccessEmptyQueue", func(t *testing.T) {
+		var elems []int
 
-			elems := []int{1, 2, 3, 4}
+		linkedQueue := queue.NewLinked(elems)
 
-			linkedQueue := queue.NewLinked(elems)
+		err := linkedQueue.Offer(1)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
 
-			_, err := linkedQueue.Get()
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
+		err = linkedQueue.Offer(2)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
 
-			if linkedQueue.Contains(1) {
-				t.Fatal("expected elem to not be found")
-			}
-		})
+		if linkedQueue.Size() != 2 {
+			t.Fatalf("expected size to be 2, got %d", linkedQueue.Size())
+		}
 
-		t.Run("EmptyQueue", func(t *testing.T) {
-			linkedQueue := queue.NewLinked([]int{})
+		queueElems := linkedQueue.Clear()
+		expectedElems := []int{1, 2}
 
-			if linkedQueue.Contains(1) {
-				t.Fatal("expected elem to not be found")
-			}
-		})
+		if !reflect.DeepEqual(expectedElems, queueElems) {
+			t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
+		}
+	})
+}
+
+func testLinkedContains(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{1, 2, 3, 4}
+
+		linkedQueue := queue.NewLinked(elems)
+
+		if !linkedQueue.Contains(2) {
+			t.Fatal("expected elem to be found")
+		}
 	})
 
-	t.Run("Clear", func(t *testing.T) {
+	t.Run("NotFoundAfterGet", func(t *testing.T) {
 		t.Parallel()
 
 		elems := []int{1, 2, 3, 4}
@@ -171,86 +156,111 @@ func TestLinked(t *testing.T) {
 			t.Fatalf("expected no error, got %v", err)
 		}
 
-		queueElems := linkedQueue.Clear()
-		expectedElems := []int{2, 3, 4}
-
-		if !reflect.DeepEqual(expectedElems, queueElems) {
-			t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
+		if linkedQueue.Contains(1) {
+			t.Fatal("expected elem to not be found")
 		}
 	})
 
-	t.Run("IsEmpty", func(t *testing.T) {
+	t.Run("EmptyQueue", func(t *testing.T) {
 		linkedQueue := queue.NewLinked([]int{})
 
-		if !linkedQueue.IsEmpty() {
-			t.Fatal("expected queue to be empty")
+		if linkedQueue.Contains(1) {
+			t.Fatal("expected elem to not be found")
 		}
 	})
+}
 
-	t.Run("Reset", func(t *testing.T) {
-		elems := []int{1, 2, 3, 4}
+func testLinkedClear(t *testing.T) {
+	t.Parallel()
 
-		linkedQueue := queue.NewLinked(elems)
+	elems := []int{1, 2, 3, 4}
 
-		err := linkedQueue.Offer(5)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
+	linkedQueue := queue.NewLinked(elems)
 
-		err = linkedQueue.Offer(6)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
+	_, err := linkedQueue.Get()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 
-		linkedQueue.Reset()
+	queueElems := linkedQueue.Clear()
+	expectedElems := []int{2, 3, 4}
 
-		queueElems := linkedQueue.Clear()
-		expectedElems := []int{1, 2, 3, 4}
+	if !reflect.DeepEqual(expectedElems, queueElems) {
+		t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
+	}
+}
 
-		if !reflect.DeepEqual(expectedElems, queueElems) {
-			t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
-		}
-	})
+func testLinkedIsEmpty(t *testing.T) {
+	linkedQueue := queue.NewLinked([]int{})
 
-	t.Run("Iterator", func(t *testing.T) {
-		elems := []int{1, 2, 3, 4}
+	if !linkedQueue.IsEmpty() {
+		t.Fatal("expected queue to be empty")
+	}
+}
 
-		linkedQueue := queue.NewLinked(elems)
+func testLinkedReset(t *testing.T) {
+	elems := []int{1, 2, 3, 4}
 
-		iterCh := linkedQueue.Iterator()
+	linkedQueue := queue.NewLinked(elems)
 
-		if !linkedQueue.IsEmpty() {
-			t.Fatal("expected queue to be empty")
-		}
+	err := linkedQueue.Offer(5)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 
-		iterElems := make([]int, 0, len(elems))
+	err = linkedQueue.Offer(6)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 
-		for e := range iterCh {
-			iterElems = append(iterElems, e)
-		}
+	linkedQueue.Reset()
 
-		if !reflect.DeepEqual(elems, iterElems) {
-			t.Fatalf("expected elements to be %v, got %v", elems, iterElems)
-		}
-	})
+	queueElems := linkedQueue.Clear()
+	expectedElems := []int{1, 2, 3, 4}
 
-	t.Run("MarshalJSON", func(t *testing.T) {
-		t.Parallel()
+	if !reflect.DeepEqual(expectedElems, queueElems) {
+		t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
+	}
+}
 
-		elems := []int{3, 2, 1}
+func testLinkedIterator(t *testing.T) {
+	elems := []int{1, 2, 3, 4}
 
-		q := queue.NewLinked(elems)
+	linkedQueue := queue.NewLinked(elems)
 
-		marshaled, err := json.Marshal(q)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
+	iterCh := linkedQueue.Iterator()
 
-		expectedMarshaled := []byte(`[3,2,1]`)
-		if !bytes.Equal(expectedMarshaled, marshaled) {
-			t.Fatalf("expected marshaled to be %s, got %s", expectedMarshaled, marshaled)
-		}
-	})
+	if !linkedQueue.IsEmpty() {
+		t.Fatal("expected queue to be empty")
+	}
+
+	iterElems := make([]int, 0, len(elems))
+
+	for e := range iterCh {
+		iterElems = append(iterElems, e)
+	}
+
+	if !reflect.DeepEqual(elems, iterElems) {
+		t.Fatalf("expected elements to be %v, got %v", elems, iterElems)
+	}
+}
+
+func testLinkedMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	elems := []int{3, 2, 1}
+
+	q := queue.NewLinked(elems)
+
+	marshaled, err := json.Marshal(q)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	expectedMarshaled := []byte(`[3,2,1]`)
+	if !bytes.Equal(expectedMarshaled, marshaled) {
+		t.Fatalf("expected marshaled to be %s, got %s", expectedMarshaled, marshaled)
+	}
 }
 
 func BenchmarkLinkedQueue(b *testing.B) {

--- a/priority.go
+++ b/priority.go
@@ -155,12 +155,12 @@ func (pq *Priority[T]) Reset() {
 	pq.lock.Lock()
 	defer pq.lock.Unlock()
 
-	if pq.elements.Len() > len(pq.initialElements) {
-		pq.elements.elems = (pq.elements.elems)[:len(pq.initialElements)]
-	}
+	n := len(pq.initialElements)
 
-	if pq.elements.Len() < len(pq.initialElements) {
-		pq.elements.elems = make([]T, len(pq.initialElements))
+	if cap(pq.elements.elems) >= n {
+		pq.elements.elems = pq.elements.elems[:n]
+	} else {
+		pq.elements.elems = make([]T, n)
 	}
 
 	copy(pq.elements.elems, pq.initialElements)

--- a/priority.go
+++ b/priority.go
@@ -207,8 +207,8 @@ func (pq *Priority[T]) Clear() []T {
 // Iterator returns an iterator over the elements in the queue.
 // It removes the elements from the queue.
 func (pq *Priority[T]) Iterator() <-chan T {
-	pq.lock.RLock()
-	defer pq.lock.RUnlock()
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
 
 	// use a buffered channel to avoid blocking the iterator.
 	iteratorCh := make(chan T, pq.elements.Len())

--- a/priority.go
+++ b/priority.go
@@ -155,14 +155,7 @@ func (pq *Priority[T]) Reset() {
 	pq.lock.Lock()
 	defer pq.lock.Unlock()
 
-	n := len(pq.initialElements)
-
-	if cap(pq.elements.elems) >= n {
-		pq.elements.elems = pq.elements.elems[:n]
-	} else {
-		pq.elements.elems = make([]T, n)
-	}
-
+	pq.elements.elems = pq.elements.elems[:len(pq.initialElements)]
 	copy(pq.elements.elems, pq.initialElements)
 }
 

--- a/priority_test.go
+++ b/priority_test.go
@@ -11,377 +11,387 @@ import (
 	"github.com/adrianbrad/queue"
 )
 
+func lessInt(elem, elemAfter int) bool {
+	return elem < elemAfter
+}
+
 func TestPriority(t *testing.T) {
 	t.Parallel()
 
-	lessAscending := func(elem, elemAfter int) bool {
-		return elem < elemAfter
+	t.Run("NilLessFunc", testPriorityNilLessFunc)
+	t.Run("CapacityLesserThanLenElems", testPriorityCapacityLesserThanLenElems)
+	t.Run("Offer", testPriorityOffer)
+	t.Run("Get", testPriorityGet)
+	t.Run("Clear", testPriorityClear)
+	t.Run("Contains", testPriorityContains)
+	t.Run("Iterator", testPriorityIterator)
+	t.Run("IsEmpty", testPriorityIsEmpty)
+	t.Run("Peek", testPriorityPeek)
+	t.Run("Reset", testPriorityReset)
+	t.Run("MarshalJSON", testPriorityMarshalJSON)
+}
+
+func testPriorityNilLessFunc(t *testing.T) {
+	defer func() {
+		p := recover()
+		if p != "nil less func" {
+			t.Fatalf("expected panic to be 'nil less func', got %v", p)
+		}
+	}()
+
+	queue.NewPriority[any](nil, nil)
+}
+
+func testPriorityCapacityLesserThanLenElems(t *testing.T) {
+	t.Parallel()
+
+	elems := []int{4, 1, 2}
+
+	priorityQueue := queue.NewPriority(elems, lessInt, queue.WithCapacity(2))
+
+	size := priorityQueue.Size()
+
+	if priorityQueue.Size() != 2 {
+		t.Fatalf("expected size to be 2, got %d with elements: %v", size, priorityQueue.Clear())
 	}
 
-	lessInt := func(elem, elemAfter int) bool {
-		return elem < elemAfter
+	elems = priorityQueue.Clear()
+	expectedElems := []int{1, 2}
+
+	if !reflect.DeepEqual([]int{1, 2}, elems) {
+		t.Fatalf("expected elements to be %v, got %v", expectedElems, elems)
 	}
+}
 
-	t.Run("NilLessFunc", func(t *testing.T) {
-		defer func() {
-			p := recover()
-			if p != "nil less func" {
-				t.Fatalf("expected panic to be 'nil less func', got %v", p)
-			}
-		}()
+func testPriorityOffer(t *testing.T) {
+	t.Parallel()
 
-		queue.NewPriority[any](nil, nil)
-	})
-
-	t.Run("CapacityLesserThanLenElems", func(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 
 		elems := []int{4, 1, 2}
 
-		priorityQueue := queue.NewPriority(elems, lessInt, queue.WithCapacity(2))
+		priorityQueue := queue.NewPriority(elems, lessInt)
+
+		if err := priorityQueue.Offer(5); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
 
 		size := priorityQueue.Size()
 
-		if priorityQueue.Size() != 2 {
-			t.Fatalf("expected size to be 2, got %d with elements: %v", size, priorityQueue.Clear())
+		if size != 4 {
+			t.Fatalf("expected size to be 4, got %d", size)
 		}
 
-		elems = priorityQueue.Clear()
-		expectedElems := []int{1, 2}
+		queueElems := priorityQueue.Clear()
+		expectedElems := []int{1, 2, 4, 5}
 
-		if !reflect.DeepEqual([]int{1, 2}, elems) {
-			t.Fatalf("expected elements to be %v, got %v", expectedElems, elems)
+		if !reflect.DeepEqual(expectedElems, queueElems) {
+			t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
 		}
-	})
 
-	t.Run("Offer", func(t *testing.T) {
-		t.Parallel()
+		newElems := make([]int, 10)
 
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
+		for j := 19; j >= 10; j-- {
+			newElems[j%10] = j
 
-			elems := []int{4, 1, 2}
-
-			priorityQueue := queue.NewPriority(elems, lessAscending)
-
-			if err := priorityQueue.Offer(5); err != nil {
+			if err := priorityQueue.Offer(j); err != nil {
 				t.Fatalf("expected no error, got %v", err)
 			}
-
-			size := priorityQueue.Size()
-
-			if size != 4 {
-				t.Fatalf("expected size to be 4, got %d", size)
-			}
-
-			queueElems := priorityQueue.Clear()
-			expectedElems := []int{1, 2, 4, 5}
-
-			if !reflect.DeepEqual(expectedElems, queueElems) {
-				t.Fatalf("expected elements to be %v, got %v", expectedElems, queueElems)
-			}
-
-			newElems := make([]int, 10)
-
-			for j := 19; j >= 10; j-- {
-				newElems[j%10] = j
-
-				if err := priorityQueue.Offer(j); err != nil {
-					t.Fatalf("expected no error, got %v", err)
-				}
-			}
-
-			queueElems = priorityQueue.Clear()
-			if !reflect.DeepEqual(newElems, queueElems) {
-				t.Fatalf("expected elements to be %v, got %v", newElems, queueElems)
-			}
-		})
-
-		t.Run("ErrQueueIsFull", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1}
-
-			priorityQueue := queue.NewPriority(
-				elems, lessAscending,
-				queue.WithCapacity(1),
-			)
-
-			if err := priorityQueue.Offer(2); !errors.Is(err, queue.ErrQueueIsFull) {
-				t.Fatalf("expected error to be %v, got %v", queue.ErrQueueIsFull, err)
-			}
-		})
-	})
-
-	t.Run("Get", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{4, 1, 2}
-
-			priorityQueue := queue.NewPriority(elems, lessInt)
-
-			elem, err := priorityQueue.Get()
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			if elem != 1 {
-				t.Fatalf("expected elem to be 1, got %d", elem)
-			}
-
-			size := priorityQueue.Size()
-
-			if size != 2 {
-				t.Fatalf("expected size to be 2, got %d", size)
-			}
-		})
-
-		t.Run("ErrNoElementsAvailable", func(t *testing.T) {
-			t.Parallel()
-
-			priorityQueue := queue.NewPriority([]int{}, func(_, _ int) bool { return false })
-
-			if _, err := priorityQueue.Get(); !errors.Is(err, queue.ErrNoElementsAvailable) {
-				t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
-			}
-		})
-	})
-
-	t.Run("Clear", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2, 3}
-
-			priorityQueue := queue.NewPriority(elems, lessAscending)
-
-			queueElems := priorityQueue.Clear()
-
-			if !reflect.DeepEqual(elems, queueElems) {
-				t.Fatalf("expected elements to be %v, got %v", elems, queueElems)
-			}
-		})
-
-		t.Run("Empty", func(t *testing.T) {
-			t.Parallel()
-
-			priorityQueue := queue.NewPriority([]int{}, lessAscending)
-
-			queueElems := priorityQueue.Clear()
-
-			if len(queueElems) != 0 {
-				t.Fatalf("expected elements to be empty, got %v", queueElems)
-			}
-		})
-	})
-
-	t.Run("Contains", func(t *testing.T) {
-		t.Parallel()
-
-		t.Run("True", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2, 3}
-
-			priorityQueue := queue.NewPriority(elems, lessAscending)
-
-			if !priorityQueue.Contains(2) {
-				t.Fatal("expected queue to contain 2")
-			}
-		})
-
-		t.Run("False", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2, 3}
-
-			priorityQueue := queue.NewPriority(elems, lessAscending)
-
-			if priorityQueue.Contains(4) {
-				t.Fatal("expected queue to not contain 4")
-			}
-		})
-	})
-
-	t.Run("Iterator", func(t *testing.T) {
-		t.Parallel()
-
-		elems := []int{1, 2, 3}
-
-		priorityQueue := queue.NewPriority(elems, lessAscending)
-
-		iterCh := priorityQueue.Iterator()
-
-		if !priorityQueue.IsEmpty() {
-			t.Fatal("expected queue to be empty")
 		}
 
-		iterElems := make([]int, 0, len(elems))
-
-		for e := range iterCh {
-			iterElems = append(iterElems, e)
-		}
-
-		if !reflect.DeepEqual(elems, iterElems) {
-			t.Fatalf("expected elements to be %v, got %v", elems, iterElems)
+		queueElems = priorityQueue.Clear()
+		if !reflect.DeepEqual(newElems, queueElems) {
+			t.Fatalf("expected elements to be %v, got %v", newElems, queueElems)
 		}
 	})
 
-	t.Run("IsEmpty", func(t *testing.T) {
+	t.Run("ErrQueueIsFull", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("True", func(t *testing.T) {
-			t.Parallel()
+		elems := []int{1}
 
-			priorityQueue := queue.NewPriority([]int{}, lessAscending)
+		priorityQueue := queue.NewPriority(
+			elems, lessInt,
+			queue.WithCapacity(1),
+		)
 
-			if !priorityQueue.IsEmpty() {
-				t.Fatal("expected queue to be empty")
-			}
-		})
-
-		t.Run("False", func(t *testing.T) {
-			t.Parallel()
-
-			priorityQueue := queue.NewPriority([]int{1}, lessAscending)
-
-			if priorityQueue.IsEmpty() {
-				t.Fatal("expected queue to not be empty")
-			}
-		})
+		if err := priorityQueue.Offer(2); !errors.Is(err, queue.ErrQueueIsFull) {
+			t.Fatalf("expected error to be %v, got %v", queue.ErrQueueIsFull, err)
+		}
 	})
+}
 
-	t.Run("Peek", func(t *testing.T) {
+func testPriorityGet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("Success", func(t *testing.T) {
-			t.Parallel()
+		elems := []int{4, 1, 2}
 
-			elems := []int{4, 1, 2}
+		priorityQueue := queue.NewPriority(elems, lessInt)
 
-			priorityQueue := queue.NewPriority(elems, lessAscending)
-
-			elem, err := priorityQueue.Peek()
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			size := priorityQueue.Size()
-
-			if size != 3 {
-				t.Fatalf("expected size to be 3, got %d", size)
-			}
-
-			if elem != 1 {
-				t.Fatalf("expected elem to be 1, got %d", elem)
-			}
-
-			elem, err = priorityQueue.Get()
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			if elem != 1 {
-				t.Fatalf("expected elem to be 1, got %d", elem)
-			}
-
-			elem, err = priorityQueue.Peek()
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			size = priorityQueue.Size()
-
-			if size != 2 {
-				t.Fatalf("expected size to be 2, got %d", size)
-			}
-
-			if elem != 2 {
-				t.Fatalf("expected elem to be 2, got %d", elem)
-			}
-
-			elem, err = priorityQueue.Get()
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			if elem != 2 {
-				t.Fatalf("expected elem to be 2, got %d", elem)
-			}
-		})
-
-		t.Run("ErrNoElementsAvailable", func(t *testing.T) {
-			t.Parallel()
-
-			priorityQueue := queue.NewPriority([]int{}, func(_, _ int) bool { return false })
-
-			if _, err := priorityQueue.Peek(); !errors.Is(err, queue.ErrNoElementsAvailable) {
-				t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
-			}
-		})
-	})
-
-	t.Run("Reset", func(t *testing.T) {
-		t.Run("SizeGreaterThanInitialElems", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1}
-
-			priorityQueue := queue.NewPriority(elems, lessAscending)
-
-			err := priorityQueue.Offer(2)
-			if err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			priorityQueue.Reset()
-
-			if priorityQueue.Size() != 1 {
-				t.Fatalf("expected size to be 1, got %d", priorityQueue.Size())
-			}
-		})
-
-		t.Run("SizeLesserThanInitialElems", func(t *testing.T) {
-			t.Parallel()
-
-			elems := []int{1, 2}
-
-			priorityQueue := queue.NewPriority(elems, lessAscending)
-
-			if _, err := priorityQueue.Get(); err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-
-			priorityQueue.Reset()
-
-			if priorityQueue.Size() != 2 {
-				t.Fatalf("expected size to be 2, got %d", priorityQueue.Size())
-			}
-		})
-	})
-
-	t.Run("MarshalJSON", func(t *testing.T) {
-		t.Parallel()
-
-		elems := []int{3, 2, 1}
-
-		priorityQueue := queue.NewPriority(elems, lessAscending)
-
-		marshaled, err := json.Marshal(priorityQueue)
+		elem, err := priorityQueue.Get()
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
 
-		expectedMarshaled := []byte(`[3,2,1]`)
-		if !bytes.Equal(expectedMarshaled, marshaled) {
-			t.Fatalf("expected marshaled to be %s, got %s", expectedMarshaled, marshaled)
+		if elem != 1 {
+			t.Fatalf("expected elem to be 1, got %d", elem)
+		}
+
+		size := priorityQueue.Size()
+
+		if size != 2 {
+			t.Fatalf("expected size to be 2, got %d", size)
 		}
 	})
+
+	t.Run("ErrNoElementsAvailable", func(t *testing.T) {
+		t.Parallel()
+
+		priorityQueue := queue.NewPriority([]int{}, func(_, _ int) bool { return false })
+
+		if _, err := priorityQueue.Get(); !errors.Is(err, queue.ErrNoElementsAvailable) {
+			t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
+		}
+	})
+}
+
+func testPriorityClear(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{1, 2, 3}
+
+		priorityQueue := queue.NewPriority(elems, lessInt)
+
+		queueElems := priorityQueue.Clear()
+
+		if !reflect.DeepEqual(elems, queueElems) {
+			t.Fatalf("expected elements to be %v, got %v", elems, queueElems)
+		}
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+
+		priorityQueue := queue.NewPriority([]int{}, lessInt)
+
+		queueElems := priorityQueue.Clear()
+
+		if len(queueElems) != 0 {
+			t.Fatalf("expected elements to be empty, got %v", queueElems)
+		}
+	})
+}
+
+func testPriorityContains(t *testing.T) {
+	t.Parallel()
+
+	t.Run("True", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{1, 2, 3}
+
+		priorityQueue := queue.NewPriority(elems, lessInt)
+
+		if !priorityQueue.Contains(2) {
+			t.Fatal("expected queue to contain 2")
+		}
+	})
+
+	t.Run("False", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{1, 2, 3}
+
+		priorityQueue := queue.NewPriority(elems, lessInt)
+
+		if priorityQueue.Contains(4) {
+			t.Fatal("expected queue to not contain 4")
+		}
+	})
+}
+
+func testPriorityIterator(t *testing.T) {
+	t.Parallel()
+
+	elems := []int{1, 2, 3}
+
+	priorityQueue := queue.NewPriority(elems, lessInt)
+
+	iterCh := priorityQueue.Iterator()
+
+	if !priorityQueue.IsEmpty() {
+		t.Fatal("expected queue to be empty")
+	}
+
+	iterElems := make([]int, 0, len(elems))
+
+	for e := range iterCh {
+		iterElems = append(iterElems, e)
+	}
+
+	if !reflect.DeepEqual(elems, iterElems) {
+		t.Fatalf("expected elements to be %v, got %v", elems, iterElems)
+	}
+}
+
+func testPriorityIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	t.Run("True", func(t *testing.T) {
+		t.Parallel()
+
+		priorityQueue := queue.NewPriority([]int{}, lessInt)
+
+		if !priorityQueue.IsEmpty() {
+			t.Fatal("expected queue to be empty")
+		}
+	})
+
+	t.Run("False", func(t *testing.T) {
+		t.Parallel()
+
+		priorityQueue := queue.NewPriority([]int{1}, lessInt)
+
+		if priorityQueue.IsEmpty() {
+			t.Fatal("expected queue to not be empty")
+		}
+	})
+}
+
+func testPriorityPeek(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", testPriorityPeekSuccess)
+
+	t.Run("ErrNoElementsAvailable", func(t *testing.T) {
+		t.Parallel()
+
+		priorityQueue := queue.NewPriority([]int{}, func(_, _ int) bool { return false })
+
+		if _, err := priorityQueue.Peek(); !errors.Is(err, queue.ErrNoElementsAvailable) {
+			t.Fatalf("expected error to be %v, got %v", queue.ErrNoElementsAvailable, err)
+		}
+	})
+}
+
+func testPriorityPeekSuccess(t *testing.T) {
+	t.Parallel()
+
+	elems := []int{4, 1, 2}
+
+	priorityQueue := queue.NewPriority(elems, lessInt)
+
+	elem, err := priorityQueue.Peek()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	size := priorityQueue.Size()
+
+	if size != 3 {
+		t.Fatalf("expected size to be 3, got %d", size)
+	}
+
+	if elem != 1 {
+		t.Fatalf("expected elem to be 1, got %d", elem)
+	}
+
+	elem, err = priorityQueue.Get()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if elem != 1 {
+		t.Fatalf("expected elem to be 1, got %d", elem)
+	}
+
+	elem, err = priorityQueue.Peek()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	size = priorityQueue.Size()
+
+	if size != 2 {
+		t.Fatalf("expected size to be 2, got %d", size)
+	}
+
+	if elem != 2 {
+		t.Fatalf("expected elem to be 2, got %d", elem)
+	}
+
+	elem, err = priorityQueue.Get()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if elem != 2 {
+		t.Fatalf("expected elem to be 2, got %d", elem)
+	}
+}
+
+func testPriorityReset(t *testing.T) {
+	t.Run("SizeGreaterThanInitialElems", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{1}
+
+		priorityQueue := queue.NewPriority(elems, lessInt)
+
+		err := priorityQueue.Offer(2)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		priorityQueue.Reset()
+
+		if priorityQueue.Size() != 1 {
+			t.Fatalf("expected size to be 1, got %d", priorityQueue.Size())
+		}
+	})
+
+	t.Run("SizeLesserThanInitialElems", func(t *testing.T) {
+		t.Parallel()
+
+		elems := []int{1, 2}
+
+		priorityQueue := queue.NewPriority(elems, lessInt)
+
+		if _, err := priorityQueue.Get(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		priorityQueue.Reset()
+
+		if priorityQueue.Size() != 2 {
+			t.Fatalf("expected size to be 2, got %d", priorityQueue.Size())
+		}
+	})
+}
+
+func testPriorityMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	elems := []int{3, 2, 1}
+
+	priorityQueue := queue.NewPriority(elems, lessInt)
+
+	marshaled, err := json.Marshal(priorityQueue)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	expectedMarshaled := []byte(`[3,2,1]`)
+	if !bytes.Equal(expectedMarshaled, marshaled) {
+		t.Fatalf("expected marshaled to be %s, got %s", expectedMarshaled, marshaled)
+	}
 }
 
 func FuzzPriority(f *testing.F) {

--- a/priority_test.go
+++ b/priority_test.go
@@ -191,7 +191,7 @@ func TestPriority(t *testing.T) {
 			priorityQueue := queue.NewPriority(elems, lessAscending)
 
 			if !priorityQueue.Contains(2) {
-				t.Fatalf("expected queue to contain 2")
+				t.Fatal("expected queue to contain 2")
 			}
 		})
 
@@ -203,7 +203,7 @@ func TestPriority(t *testing.T) {
 			priorityQueue := queue.NewPriority(elems, lessAscending)
 
 			if priorityQueue.Contains(4) {
-				t.Fatalf("expected queue to not contain 4")
+				t.Fatal("expected queue to not contain 4")
 			}
 		})
 	})
@@ -218,7 +218,7 @@ func TestPriority(t *testing.T) {
 		iterCh := priorityQueue.Iterator()
 
 		if !priorityQueue.IsEmpty() {
-			t.Fatalf("expected queue to be empty")
+			t.Fatal("expected queue to be empty")
 		}
 
 		iterElems := make([]int, 0, len(elems))
@@ -241,7 +241,7 @@ func TestPriority(t *testing.T) {
 			priorityQueue := queue.NewPriority([]int{}, lessAscending)
 
 			if !priorityQueue.IsEmpty() {
-				t.Fatalf("expected queue to be empty")
+				t.Fatal("expected queue to be empty")
 			}
 		})
 
@@ -251,7 +251,7 @@ func TestPriority(t *testing.T) {
 			priorityQueue := queue.NewPriority([]int{1}, lessAscending)
 
 			if priorityQueue.IsEmpty() {
-				t.Fatalf("expected queue to not be empty")
+				t.Fatal("expected queue to not be empty")
 			}
 		})
 	})


### PR DESCRIPTION
## Summary

- **Perf**: `Circular`/`Linked`/`Priority` preallocate result slices and use indexed writes instead of `append`; `Linked.Iterator` fills a buffered channel synchronously instead of spawning a goroutine; `Priority.Reset` reuses the existing backing array when capacity suffices.
- **Correctness**: `Iterator()` on `Blocking`/`Priority`/`Circular` now takes a write lock (it actually mutates the queue); `Circular.Contains` loop bounds fixed (pre-existing bug: a non-zero `head` caused skipped elements and out-of-range indices); `Circular.drainQueue` loop was draining only half of elements because it read the mutating `q.size` — now captures size up front.
- **Test hygiene**: `TestBlocking` (gocognit 74) and `TestCircular` (gocognit 38) split into per-group helpers to drop under the complexity budget; 18 `t.Fatalf`/`t.Logf` calls without format args collapsed to `t.Fatal`/`t.Log`; shared 21-line demo between `ExampleLinked` and `ExamplePriority` extracted to a helper.
- **Lint**: golangci config migrated off deprecated `wsl` to `wsl_v5`; `copyloopvar`/`intrange` removed (need Go 1.22; module stays on 1.20).
- **CI**: all workflow actions bumped to current majors (`checkout@v6`, `setup-go@v6`, `golangci-lint-action@v9`, `codecov-action@v6`, `scan-action@v7`, `codeql-action@v4`); new Dependabot auto-merge workflow for patch + minor updates (majors still manual).
- **Chore**: `.gitignore` adds `.claude` and `.env`.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test -race -count=3 ./...` passes
- [x] `make lint` reports 0 issues
- [ ] CI (lint-test, codeql, grype, gitleaks) green on the PR
- [ ] Enable "Allow auto-merge" in repo settings if not already on (required for the new Dependabot workflow to function)