### PR TITLE
Harden repo per OpenSSF Scorecard

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -4,10 +4,11 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
   schedule:
     - cron: '0 0 1 * *' # once a month
+
+permissions:
+  contents: read
 
 jobs:
   analyze:
@@ -15,23 +16,21 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      # required for all workflows
       security-events: write
-      # only required for workflows in private repositories
+      actions: read
       contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
         with:
           languages: go
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -3,18 +3,20 @@ name: dependabot-auto-merge
 on: pull_request
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge:
     name: auto-merge
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -9,10 +9,10 @@ jobs:
     name: gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/grype.yaml
+++ b/.github/workflows/grype.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   scan-source:
     name: scan-source
@@ -15,8 +18,8 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: anchore/scan-action@v7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
           path: "."
           fail-build: true

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -5,21 +5,24 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: stable
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: latest
           args: --timeout 5m
@@ -29,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: stable
 
@@ -51,7 +54,7 @@ jobs:
           echo "coverage: $total"
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.txt

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,45 @@
+name: scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '0 0 * * 1' # weekly on Monday
+  push:
+    branches: [ main ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@f443b600d91635bebf5b0d9ebc620189c0d6fba5 # v4.30.8
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/adrianbrad/queue)](https://goreportcard.com/report/github.com/adrianbrad/queue)
 [![codecov](https://codecov.io/gh/adrianbrad/queue/branch/main/graph/badge.svg)](https://codecov.io/gh/adrianbrad/queue)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/adrianbrad/queue/badge)](https://scorecard.dev/viewer/?uri=github.com/adrianbrad/queue)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12607/badge)](https://www.bestpractices.dev/projects/12607)
 
 [![lint-test](https://github.com/adrianbrad/queue/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/adrianbrad/queue/actions?query=workflow%3Alint-test)
 [![grype](https://github.com/adrianbrad/queue/actions/workflows/grype.yaml/badge.svg)](https://github.com/adrianbrad/queue/actions?query=workflow%3Agrype)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/adrianbrad/queue/badge)](https://www.codefactor.io/repository/github/adrianbrad/queue)
 [![Go Report Card](https://goreportcard.com/badge/github.com/adrianbrad/queue)](https://goreportcard.com/report/github.com/adrianbrad/queue)
 [![codecov](https://codecov.io/gh/adrianbrad/queue/branch/main/graph/badge.svg)](https://codecov.io/gh/adrianbrad/queue)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/adrianbrad/queue/badge)](https://scorecard.dev/viewer/?uri=github.com/adrianbrad/queue)
 
 [![lint-test](https://github.com/adrianbrad/queue/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/adrianbrad/queue/actions?query=workflow%3Alint-test)
 [![grype](https://github.com/adrianbrad/queue/actions/workflows/grype.yaml/badge.svg)](https://github.com/adrianbrad/queue/actions?query=workflow%3Agrype)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest `v1.x` release receives security fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| 1.x     | ✓         |
+| < 1.0   | ✗         |
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report vulnerabilities privately through GitHub Security Advisories:
+
+<https://github.com/adrianbrad/queue/security/advisories/new>
+
+Include:
+
+- A description of the issue and its impact.
+- Steps to reproduce or a proof-of-concept.
+- Affected version(s).
+- Any known mitigation or workaround.
+
+## Response SLA
+
+- Acknowledgement: within **7 days** of the initial report.
+- Triage and disposition (accepted, declined, or needs more info): within **14 days**.
+- Fix or coordinated disclosure plan: within **30 days** for confirmed issues.
+
+## Disclosure
+
+Once a fix is released, the advisory is published on GitHub. Reporters are credited unless they request anonymity.


### PR DESCRIPTION
## Summary

Lifts OpenSSF Scorecard from **5.2** toward the ~7+ ceiling achievable in-code. All four fixable-in-repo checks verified at **10/10** via `scorecard --local .`.

| Check | Before | After | How |
|---|---|---|---|
| Pinned-Dependencies | 0/10 | 10/10 | Every action pinned by 40-char commit SHA with `# vX.Y.Z` trailing comment (Dependabot tracks it) |
| Token-Permissions | 0/10 | 10/10 | Workflow-level `permissions: contents: read`; write scopes granted only per-job where needed |
| Security-Policy | 0/10 | 10/10 | New `SECURITY.md` with private disclosure via GitHub Security Advisories, supported versions, response SLA |
| SAST | 7/10 | 10/10 | CodeQL `pull_request` trigger no longer restricted to PRs targeting `main` |

Also adds `.github/workflows/scorecard.yaml` — weekly OpenSSF Scorecard analysis that uploads SARIF to Code scanning, giving ongoing visibility without a local run.

## Can't fix in code (follow-up)

- **Branch-Protection (4/10)** — repo Settings: require PR review + status checks + signed commits + linear history + up-to-date branches + no force-push + include admins.
- **CII-Best-Practices (0/10)** — badge form at bestpractices.dev (select **Metal** series).
- **Maintained/CI-Tests/Code-Review/Contributors** — historical metrics; improve organically.

Realistic aggregate ceiling once everything above is in place: ~9/10 (Contributors requires 3+ distinct orgs, which is structural).

## Test plan

- [x] `scorecard --local .` against the four in-code checks → 10/10 each
- [ ] CI green (lint, test, codeql, gitleaks)
- [ ] After merge: re-run remote `scorecard --repo=...` to verify lift
- [ ] Scorecard workflow uploads SARIF to the Security tab on next main push