### PR TITLE
chore(codeowners): add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners for this repository.
+#
+# Each line is a file pattern followed by one or more owners.
+# Order matters: the last matching pattern takes the most precedence.
+# See: https://docs.github.com/articles/about-code-owners
+
+* @adrianbrad


### PR DESCRIPTION
Adds `.github/CODEOWNERS` making @adrianbrad the default owner for all paths. Enables the branch ruleset's 'Require review from Code Owners' check to match something.

Pairs with two repo settings changes to lift Scorecard's Branch-Protection score:
- Ruleset: enable **Require review from Code Owners**
- Ruleset: enable **Require approval of the most recent reviewable push**