### PR TITLE
build(release): signed releases via goreleaser + cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # create GitHub Releases
+      id-token: write # cosign keyless signing via Sigstore OIDC
+      attestations: write # build provenance
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Install syft (for SBOM generation)
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Run goreleaser
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,84 @@
+version: 2
+
+project_name: queue
+
+before:
+  hooks:
+    - go mod tidy
+
+# Library, no binaries to build.
+builds:
+  - skip: true
+
+source:
+  enabled: true
+  format: tar.gz
+  name_template: "{{ .ProjectName }}-{{ .Version }}-source"
+
+checksum:
+  name_template: "checksums.txt"
+
+sboms:
+  - id: source-sbom
+    artifacts: source
+    documents:
+      - "{{ .ProjectName }}-{{ .Version }}.spdx.json"
+
+signs:
+  - cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - --oidc-issuer=https://token.actions.githubusercontent.com
+      - --output-certificate=${certificate}
+      - --output-signature=${signature}
+      - ${artifact}
+      - --yes
+    artifacts: all
+
+release:
+  github:
+    owner: adrianbrad
+    name: queue
+  prerelease: auto
+  mode: replace
+  footer: |
+    ## Verification
+
+    All release artifacts are signed with cosign keyless signing via Sigstore.
+    To verify the checksums file, for example:
+
+    ```bash
+    cosign verify-blob \
+      --certificate checksums.txt.pem \
+      --signature checksums.txt.sig \
+      --certificate-identity-regexp '^https://github.com/adrianbrad/queue/\.github/workflows/release\.yaml@refs/tags/' \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      checksums.txt
+    ```
+
+changelog:
+  use: github
+  sort: asc
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))?!?:.+$'
+      order: 0
+    - title: Fixes
+      regexp: '^.*?fix(\(.+\))?!?:.+$'
+      order: 1
+    - title: Performance
+      regexp: '^.*?perf(\(.+\))?!?:.+$'
+      order: 2
+    - title: Other
+      order: 999
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^style:'
+      - '^build:'
+      - '^ci:'
+      - 'Merge pull request'


### PR DESCRIPTION
Adds an on-tag release workflow to close Scorecard's `Signed-Releases` gap.

## What runs on `git push --tags`

1. Checkout + Go + cosign + syft.
2. `goreleaser release --clean`, which:
   - builds a source tarball (library — `builds: skip: true`)
   - generates an SPDX SBOM with syft
   - emits `checksums.txt`
   - **signs every artifact with cosign keyless** via Sigstore (OIDC token from GITHUB_TOKEN, no GPG secrets to manage)
3. Publishes a GitHub Release with notes grouped by conventional commit type.

## Verification for consumers

Example from the generated release notes:

```bash
cosign verify-blob \
  --certificate checksums.txt.pem \
  --signature checksums.txt.sig \
  --certificate-identity-regexp '^https://github.com/adrianbrad/queue/\.github/workflows/release\.yaml@refs/tags/' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  checksums.txt
```

## Scorecard impact

- `Signed-Releases`: `?` → **10/10** (after first tagged release cuts)
- Aggregate expected jump: ~7.4 → **~8.0**

## Test plan

- [x] `goreleaser check .goreleaser.yaml` passes via `ghcr.io/goreleaser/goreleaser:latest`
- [ ] Push a patch tag (e.g. `v1.4.1`) after merge and confirm the workflow publishes a signed GitHub Release
- [ ] Rerun `scorecard --repo=...` to verify `Signed-Releases` lift