### PR TITLE
fix(priority): use heap.Pop so MarshalJSON emits priority order

### DIFF
--- a/priority.go
+++ b/priority.go
@@ -286,7 +286,7 @@ func (pq *Priority[T]) MarshalJSON() ([]byte, error) {
 
 	for tempHeap.Len() > 0 {
 		// nolint: forcetypeassert, revive
-		output[i] = tempHeap.Pop().(T)
+		output[i] = heap.Pop(tempHeap).(T)
 		i++
 	}
 

--- a/priority_test.go
+++ b/priority_test.go
@@ -379,7 +379,11 @@ func testPriorityReset(t *testing.T) {
 func testPriorityMarshalJSON(t *testing.T) {
 	t.Parallel()
 
-	elems := []int{3, 2, 1}
+	// Use an unsorted input large enough that the heap's internal layout
+	// differs from priority-sorted order. For a min-heap over
+	// [5, 3, 1, 4, 2] with less=<, heap.Init produces [1, 2, 4, 5, 3];
+	// draining via heap.Pop must yield [1, 2, 3, 4, 5].
+	elems := []int{5, 3, 1, 4, 2}
 
 	priorityQueue := queue.NewPriority(elems, lessInt)
 
@@ -388,7 +392,7 @@ func testPriorityMarshalJSON(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	expectedMarshaled := []byte(`[3,2,1]`)
+	expectedMarshaled := []byte(`[1,2,3,4,5]`)
 	if !bytes.Equal(expectedMarshaled, marshaled) {
 		t.Fatalf("expected marshaled to be %s, got %s", expectedMarshaled, marshaled)
 	}


### PR DESCRIPTION
## Summary
- `priorityHeap.Pop` (the `heap.Interface` method) just removes the last slice element without re-heapifying; only `heap.Pop` from `container/heap` drains in priority order.
- Replace `tempHeap.Pop()` → `heap.Pop(tempHeap)` in `Priority.MarshalJSON`.
- Replace the existing `MarshalJSON` test whose expected output `[3,2,1]` matched the buggy behaviour with a 5-element case where the heap's internal layout differs from priority-sorted order.

Fixes #37

## Test plan
- [x] `go test -race -shuffle=on .`
- [ ] coverage stays at 100%