### PR TITLE
fix(blocking): honour capacity when storing initial elements

### DIFF
--- a/blocking.go
+++ b/blocking.go
@@ -40,7 +40,13 @@ func NewBlocking[T comparable](
 		o.apply(&options)
 	}
 
-	// Store initial elements
+	// Trim caller elems to capacity first so initialElems reflects what
+	// actually fits in the queue; otherwise Reset can restore more elements
+	// than the queue is allowed to hold.
+	if options.capacity != nil && len(elems) > *options.capacity {
+		elems = elems[:*options.capacity]
+	}
+
 	initialElems := make([]T, len(elems))
 	copy(initialElems, elems)
 
@@ -53,12 +59,6 @@ func NewBlocking[T comparable](
 
 	queue.notEmptyCond = sync.NewCond(&queue.lock)
 	queue.notFullCond = sync.NewCond(&queue.lock)
-
-	if queue.capacity != nil {
-		if len(queue.elems) > *queue.capacity {
-			queue.elems = queue.elems[:*queue.capacity]
-		}
-	}
 
 	return queue
 }

--- a/blocking_test.go
+++ b/blocking_test.go
@@ -351,6 +351,33 @@ func testBlockingReset(t *testing.T) {
 			t.Fatal("OfferWait was not unblocked by Reset")
 		}
 	})
+
+	t.Run("InitialElemsExceedCapacity", func(t *testing.T) {
+		t.Parallel()
+
+		blockingQueue := queue.NewBlocking(
+			[]int{1, 2, 3, 4, 5},
+			queue.WithCapacity(3),
+		)
+
+		if size := blockingQueue.Size(); size != 3 {
+			t.Fatalf("expected size to be 3 after construction, got %d", size)
+		}
+
+		// Drain the queue then Reset. Reset must honour capacity rather
+		// than restoring the original slice verbatim.
+		_ = blockingQueue.Clear()
+
+		blockingQueue.Reset()
+
+		if size := blockingQueue.Size(); size != 3 {
+			t.Fatalf("expected size to be 3 after Reset, got %d", size)
+		}
+
+		if err := blockingQueue.Offer(99); !errors.Is(err, queue.ErrQueueIsFull) {
+			t.Fatalf("expected ErrQueueIsFull after Reset fills capacity, got %v", err)
+		}
+	})
 }
 
 func testBlockingOfferWait(t *testing.T) {


### PR DESCRIPTION
## Summary
- `NewBlocking` copied the caller's full slice into `initialElems` before trimming `elems` to capacity. `Reset` then restored the untrimmed set, leaving the queue above capacity and rejecting further `Offer` calls.
- Trim elems up front so `initialElems` reflects only what fits.

Fixes #38

## Test plan
- [x] `go test -race -shuffle=on .`
- [x] New sub-test covers the exceeds-capacity + Reset path.

Note: committed as a single test+fix commit (before you asked for TDD-style). Subsequent PRs split into two commits.