### PR TITLE
fix(blocking): do not alias caller's slice in NewBlocking

### DIFF
--- a/blocking.go
+++ b/blocking.go
@@ -47,11 +47,16 @@ func NewBlocking[T comparable](
 		elems = elems[:*options.capacity]
 	}
 
+	// Copy into an owned backing slice so caller mutations don't leak
+	// into queue state, matching NewCircular / NewLinked / NewPriority.
+	ownedElems := make([]T, len(elems))
+	copy(ownedElems, elems)
+
 	initialElems := make([]T, len(elems))
 	copy(initialElems, elems)
 
 	queue := &Blocking[T]{
-		elems:        elems,
+		elems:        ownedElems,
 		initialElems: initialElems,
 		capacity:     options.capacity,
 		lock:         sync.RWMutex{},

--- a/blocking_test.go
+++ b/blocking_test.go
@@ -31,6 +31,28 @@ func TestBlocking(t *testing.T) {
 	t.Run("WithCapacity", testBlockingWithCapacity)
 	t.Run("CondWaitWithCapacity", testBlockingCondWaitWithCapacity)
 	t.Run("MarshalJSON", testBlockingMarshalJSON)
+	t.Run("NewDoesNotAliasCallerSlice", testBlockingNewDoesNotAliasCallerSlice)
+}
+
+func testBlockingNewDoesNotAliasCallerSlice(t *testing.T) {
+	t.Parallel()
+
+	callerSlice := []int{10, 20, 30}
+
+	blockingQueue := queue.NewBlocking(callerSlice)
+
+	// Mutating the caller's slice after construction must not leak
+	// into the queue's state.
+	callerSlice[0] = 999
+
+	peek, err := blockingQueue.Peek()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if peek != 10 {
+		t.Fatalf("expected peek to be 10 (isolated), got %d", peek)
+	}
 }
 
 func testBlockingConsistency(t *testing.T) {


### PR DESCRIPTION
## Summary
- `NewBlocking` stored the caller's slice directly. Caller mutations after construction leaked into queue state — behaviour inconsistent with `NewCircular` / `NewLinked` / `NewPriority`.
- Copy into an owned backing slice. Failing test first (commit 1), then the fix (commit 2).

Fixes #41

## Test plan
- [x] `go test -race -shuffle=on .`
- [x] New test fails on main, passes with the fix.