### PR TITLE
fix: validate capacity in NewCircular and NewPriority

### DIFF
--- a/circular.go
+++ b/circular.go
@@ -44,6 +44,10 @@ func NewCircular[T comparable](
 		o.apply(&options)
 	}
 
+	if *options.capacity <= 0 {
+		panic("capacity must be positive")
+	}
+
 	elems := make([]T, *options.capacity)
 
 	copy(elems, givenElems)

--- a/circular_test.go
+++ b/circular_test.go
@@ -24,6 +24,41 @@ func TestCircular(t *testing.T) {
 	t.Run("Reset", testCircularReset)
 	t.Run("Iterator", testCircularIterator)
 	t.Run("MarshalJSON", testCircularMarshalJSON)
+	t.Run("NonPositiveCapacity", testCircularNonPositiveCapacity)
+}
+
+func testCircularNonPositiveCapacity(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		capacity int
+	}{
+		{name: "Zero", capacity: 0},
+		{name: "Negative", capacity: -1},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			defer func() {
+				p := recover()
+				if p == nil {
+					t.Fatalf("expected panic for capacity %d", tc.capacity)
+				}
+
+				msg, ok := p.(string)
+				if !ok || msg != "capacity must be positive" {
+					t.Fatalf("expected panic 'capacity must be positive', got %v", p)
+				}
+			}()
+
+			_ = queue.NewCircular[int](nil, tc.capacity)
+		})
+	}
 }
 
 func testCircularCapacityOptionOverwrites(t *testing.T) {

--- a/priority.go
+++ b/priority.go
@@ -98,6 +98,10 @@ func NewPriority[T comparable](
 		o.apply(&options)
 	}
 
+	if options.capacity != nil && *options.capacity < 0 {
+		panic("negative capacity")
+	}
+
 	heapElems := make([]T, len(elems))
 
 	copy(heapElems, elems)

--- a/priority_test.go
+++ b/priority_test.go
@@ -29,6 +29,25 @@ func TestPriority(t *testing.T) {
 	t.Run("Peek", testPriorityPeek)
 	t.Run("Reset", testPriorityReset)
 	t.Run("MarshalJSON", testPriorityMarshalJSON)
+	t.Run("NegativeCapacity", testPriorityNegativeCapacity)
+}
+
+func testPriorityNegativeCapacity(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		p := recover()
+		if p == nil {
+			t.Fatal("expected panic for negative capacity")
+		}
+
+		msg, ok := p.(string)
+		if !ok || msg != "negative capacity" {
+			t.Fatalf("expected panic 'negative capacity', got %v", p)
+		}
+	}()
+
+	_ = queue.NewPriority([]int{1, 2}, lessInt, queue.WithCapacity(-1))
 }
 
 func testPriorityNilLessFunc(t *testing.T) {


### PR DESCRIPTION
## Summary
- `NewCircular(nil, 0)` deferred its failure to the first `Offer`; `NewCircular(nil, -1)` panicked inside `make` with a cryptic runtime error; `NewPriority(..., WithCapacity(-1))` panicked inside a slice expression.
- Validate capacity at construction and panic with a clear message. Failing tests first (commit 1), then the fix (commit 2).

Fixes #42

## Test plan
- [x] `go test -race -shuffle=on .`
- [x] New tests fail on main, pass with the fix.