### PR TITLE
fix(blocking): drop popped references so pointer T is reclaimable

### DIFF
--- a/blocking.go
+++ b/blocking.go
@@ -288,8 +288,8 @@ func (bq *Blocking[T]) get() (v T, _ error) {
 	// popped element; otherwise pointer T leaks until the slice eventually
 	// reallocates.
 	var zero T
-	bq.elems[0] = zero
 
+	bq.elems[0] = zero
 	bq.elems = bq.elems[1:]
 
 	bq.notFullCond.Signal()

--- a/blocking.go
+++ b/blocking.go
@@ -154,6 +154,15 @@ func (bq *Blocking[T]) Clear() []T {
 
 	removed := make([]T, len(bq.elems))
 	copy(removed, bq.elems)
+
+	// Drop references into the backing array so popped elements can be
+	// GC'd while the queue outlives them. elems = elems[:0] alone keeps
+	// the underlying slots populated.
+	var zero T
+	for i := range bq.elems {
+		bq.elems[i] = zero
+	}
+
 	bq.elems = bq.elems[:0]
 
 	return removed
@@ -274,6 +283,13 @@ func (bq *Blocking[T]) get() (v T, _ error) {
 	}
 
 	elem := bq.elems[0]
+
+	// Zero the popped slot so the backing array no longer references the
+	// popped element; otherwise pointer T leaks until the slice eventually
+	// reallocates.
+	var zero T
+	bq.elems[0] = zero
+
 	bq.elems = bq.elems[1:]
 
 	bq.notFullCond.Signal()

--- a/blocking_test.go
+++ b/blocking_test.go
@@ -76,7 +76,7 @@ func testBlockingGetReleasesReference(t *testing.T) {
 	deadline := time.After(time.Second)
 
 	for {
-		runtime.GC()
+		runtime.GC() //nolint:revive // explicit GC needed to drive finalizer
 
 		select {
 		case <-finalized:
@@ -129,7 +129,7 @@ func testBlockingClearReleasesReferences(t *testing.T) {
 
 	count := 0
 	for count < 3 {
-		runtime.GC()
+		runtime.GC() //nolint:revive // explicit GC needed to drive finalizer
 
 		select {
 		case <-finalized:

--- a/blocking_test.go
+++ b/blocking_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"runtime"
 	"sort"
 	"sync"
 	"testing"
@@ -32,6 +33,116 @@ func TestBlocking(t *testing.T) {
 	t.Run("CondWaitWithCapacity", testBlockingCondWaitWithCapacity)
 	t.Run("MarshalJSON", testBlockingMarshalJSON)
 	t.Run("NewDoesNotAliasCallerSlice", testBlockingNewDoesNotAliasCallerSlice)
+	t.Run("GetReleasesReference", testBlockingGetReleasesReference)
+	t.Run("ClearReleasesReferences", testBlockingClearReleasesReferences)
+}
+
+func testBlockingGetReleasesReference(t *testing.T) {
+	t.Parallel()
+
+	type payload struct{ id int }
+
+	var bq *queue.Blocking[*payload]
+
+	finalized := make(chan struct{}, 1)
+
+	// Create the payload in a nested scope so p/got don't keep it alive
+	// after the offer/get cycle.
+	func() {
+		p := &payload{id: 42}
+		runtime.SetFinalizer(p, func(*payload) {
+			finalized <- struct{}{}
+		})
+
+		bq = queue.NewBlocking[*payload](nil)
+
+		if err := bq.Offer(p); err != nil {
+			t.Fatalf("offer: %v", err)
+		}
+
+		got, err := bq.Get()
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+
+		if got != p {
+			t.Fatalf("unexpected element %v", got)
+		}
+	}()
+
+	// Queue is still live. After a successful Get, the queue must not
+	// retain the popped element. Nudge GC until the finalizer fires or
+	// we give up.
+	deadline := time.After(time.Second)
+
+	for {
+		runtime.GC()
+
+		select {
+		case <-finalized:
+			runtime.KeepAlive(bq)
+			return
+		case <-deadline:
+			runtime.KeepAlive(bq)
+			t.Fatal("popped element not finalized; backing array still holds it")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func testBlockingClearReleasesReferences(t *testing.T) {
+	t.Parallel()
+
+	type payload struct{ id int }
+
+	var bq *queue.Blocking[*payload]
+
+	finalized := make(chan struct{}, 3)
+
+	func() {
+		items := []*payload{{id: 1}, {id: 2}, {id: 3}}
+
+		for _, it := range items {
+			runtime.SetFinalizer(it, func(*payload) {
+				finalized <- struct{}{}
+			})
+		}
+
+		bq = queue.NewBlocking[*payload](nil)
+
+		for _, it := range items {
+			if err := bq.Offer(it); err != nil {
+				t.Fatalf("offer: %v", err)
+			}
+		}
+
+		cleared := bq.Clear()
+		if len(cleared) != len(items) {
+			t.Fatalf("expected %d cleared, got %d", len(items), len(cleared))
+		}
+	}()
+
+	// All items should be eligible for finalization now — the queue is
+	// empty and the temporary `cleared` slice has gone out of scope.
+	deadline := time.After(time.Second)
+
+	count := 0
+	for count < 3 {
+		runtime.GC()
+
+		select {
+		case <-finalized:
+			count++
+		case <-deadline:
+			runtime.KeepAlive(bq)
+			t.Fatalf("only %d/3 payloads finalized; Clear kept references", count)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	runtime.KeepAlive(bq)
 }
 
 func testBlockingNewDoesNotAliasCallerSlice(t *testing.T) {


### PR DESCRIPTION
## Summary
- `get` did `elems[:1:]` and `Clear` did `elems[:0]`. Neither cleared the slots in the backing array, so popped elements of pointer `T` stayed reachable via the queue and were never GC'd.
- Zero the head slot in `get` and all live slots in `Clear`. Two runtime-finalizer tests first (commit 1), then the fix (commit 2).

Fixes #43

## Test plan
- [x] `go test -race -shuffle=on .`
- [x] New tests fail on main, pass with the fix.

Note: the long-term remedy in issue #43 is migrating `Blocking` to a ring buffer (same layout as `Circular`), which would also remove the per-`Offer` `append` alloc seen in the benchmark. Out of scope here — happy to open a follow-up PR if you want it.