### PR TITLE
fix(circular): release references beyond initial set on Reset

### DIFF
--- a/circular.go
+++ b/circular.go
@@ -107,6 +107,15 @@ func (q *Circular[T]) Reset() {
 
 	copy(q.elems, q.initialElements)
 
+	// Drop references in any slot past the initial set; otherwise pointer
+	// T stays reachable via the backing array until a future Offer
+	// overwrites each slot.
+	var zero T
+
+	for i := len(q.initialElements); i < len(q.elems); i++ {
+		q.elems[i] = zero
+	}
+
 	q.head = 0
 	q.tail = 0
 	q.size = len(q.initialElements)

--- a/circular_test.go
+++ b/circular_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/adrianbrad/queue"
 )
@@ -25,6 +27,56 @@ func TestCircular(t *testing.T) {
 	t.Run("Iterator", testCircularIterator)
 	t.Run("MarshalJSON", testCircularMarshalJSON)
 	t.Run("NonPositiveCapacity", testCircularNonPositiveCapacity)
+	t.Run("ResetReleasesBeyondInitial", testCircularResetReleasesBeyondInitial)
+}
+
+func testCircularResetReleasesBeyondInitial(t *testing.T) {
+	t.Parallel()
+
+	type payload struct{ id int }
+
+	var cq *queue.Circular[*payload]
+
+	finalized := make(chan struct{}, 3)
+
+	func() {
+		// Capacity 5, 2 initial elems, then offer 3 more. Reset must
+		// release the 3 extras; on unfixed code, slots 2..4 still hold
+		// them via the backing array.
+		cq = queue.NewCircular([]*payload{{id: 1}, {id: 2}}, 5)
+
+		for i := 3; i <= 5; i++ {
+			p := &payload{id: i}
+			runtime.SetFinalizer(p, func(*payload) {
+				finalized <- struct{}{}
+			})
+
+			if err := cq.Offer(p); err != nil {
+				t.Fatalf("offer: %v", err)
+			}
+		}
+
+		cq.Reset()
+	}()
+
+	deadline := time.After(time.Second)
+
+	count := 0
+	for count < 3 {
+		runtime.GC() //nolint:revive // explicit GC needed to drive finalizer
+
+		select {
+		case <-finalized:
+			count++
+		case <-deadline:
+			runtime.KeepAlive(cq)
+			t.Fatalf("only %d/3 extra payloads finalized after Reset", count)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	runtime.KeepAlive(cq)
 }
 
 func testCircularNonPositiveCapacity(t *testing.T) {


### PR DESCRIPTION
## Summary
- `Reset` copied the initial elements over the first N slots of the backing array but left slots `[N, len(elems))` populated with whatever `Offer` wrote there.
- For pointer `T` this kept popped elements reachable via the array until a future `Offer` happened to overwrite each slot. Runtime-finalizer test first (commit 1), then the fix (commit 2).

Fixes #44

## Test plan
- [x] `go test -race -shuffle=on .`
- [x] `golangci-lint run` passes locally.
- [x] New test fails on main, passes with the fix.