### PR TITLE
fix(priority): drop stale backing array on Reset

### DIFF
--- a/priority.go
+++ b/priority.go
@@ -159,7 +159,11 @@ func (pq *Priority[T]) Reset() {
 	pq.lock.Lock()
 	defer pq.lock.Unlock()
 
-	pq.elements.elems = pq.elements.elems[:len(pq.initialElements)]
+	// Allocate a fresh backing slice so any references past the new length
+	// (leftover from Offer/Pop growth) are released with the old array.
+	// initialElements was captured after heap.Init in the constructor, so
+	// copying it back preserves the heap invariant without a re-Init.
+	pq.elements.elems = make([]T, len(pq.initialElements))
 	copy(pq.elements.elems, pq.initialElements)
 }
 

--- a/priority_test.go
+++ b/priority_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"runtime"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/adrianbrad/queue"
 )
@@ -30,6 +32,60 @@ func TestPriority(t *testing.T) {
 	t.Run("Reset", testPriorityReset)
 	t.Run("MarshalJSON", testPriorityMarshalJSON)
 	t.Run("NegativeCapacity", testPriorityNegativeCapacity)
+	t.Run("ResetReleasesExtras", testPriorityResetReleasesExtras)
+}
+
+func testPriorityResetReleasesExtras(t *testing.T) {
+	t.Parallel()
+
+	type payload struct{ id int }
+
+	var pq *queue.Priority[*payload]
+
+	finalized := make(chan struct{}, 5)
+
+	lessByID := func(a, b *payload) bool { return a.id < b.id }
+
+	func() {
+		// 2 initial elems, then Offer 5 more with finalizers. Reset
+		// should make the extras reclaimable.
+		pq = queue.NewPriority(
+			[]*payload{{id: 1}, {id: 2}},
+			lessByID,
+		)
+
+		for i := 3; i <= 7; i++ {
+			p := &payload{id: i}
+			runtime.SetFinalizer(p, func(*payload) {
+				finalized <- struct{}{}
+			})
+
+			if err := pq.Offer(p); err != nil {
+				t.Fatalf("offer: %v", err)
+			}
+		}
+
+		pq.Reset()
+	}()
+
+	deadline := time.After(time.Second)
+
+	count := 0
+	for count < 5 {
+		runtime.GC() //nolint:revive // explicit GC needed to drive finalizer
+
+		select {
+		case <-finalized:
+			count++
+		case <-deadline:
+			runtime.KeepAlive(pq)
+			t.Fatalf("only %d/5 extra payloads finalized after Reset", count)
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	runtime.KeepAlive(pq)
 }
 
 func testPriorityNegativeCapacity(t *testing.T) {


### PR DESCRIPTION
## Summary
- `Reset` re-sliced the existing backing array. Any slots grown by prior `Offer` calls stayed in the array and kept pointer `T` references alive past Reset.
- Allocate a fresh backing slice. `initialElements` was captured after `heap.Init` in the constructor, so copying it back preserves the heap invariant without re-Init.
- Runtime-finalizer test first (commit 1), then the fix (commit 2).

Fixes #45

## Test plan
- [x] `go test -race -shuffle=on .`
- [x] `golangci-lint run` passes locally.
- [x] New test fails on main, passes with the fix.