### PR TITLE
fix(blocking): Broadcast on notify, drop PeekWait cascade

### DIFF
--- a/blocking.go
+++ b/blocking.go
@@ -82,7 +82,10 @@ func (bq *Blocking[T]) OfferWait(elem T) {
 
 	bq.elems = append(bq.elems, elem)
 
-	bq.notEmptyCond.Signal()
+	// Broadcast so any mix of GetWait / PeekWait waiters re-check.
+	// Signal would only wake one, requiring a cascade hack in PeekWait
+	// to forward the wake-up.
+	bq.notEmptyCond.Broadcast()
 }
 
 // Offer inserts the element to the tail the queue.
@@ -97,7 +100,7 @@ func (bq *Blocking[T]) Offer(elem T) error {
 
 	bq.elems = append(bq.elems, elem)
 
-	bq.notEmptyCond.Signal()
+	bq.notEmptyCond.Broadcast()
 
 	return nil
 }
@@ -128,10 +131,13 @@ func (bq *Blocking[T]) GetWait() (v T) {
 		bq.notEmptyCond.Wait()
 	}
 
+	var zero T
+
 	elem := bq.elems[0]
+	bq.elems[0] = zero
 	bq.elems = bq.elems[1:]
 
-	bq.notFullCond.Signal()
+	bq.notFullCond.Broadcast()
 
 	return elem
 }
@@ -219,12 +225,9 @@ func (bq *Blocking[T]) PeekWait() T {
 		bq.notEmptyCond.Wait()
 	}
 
-	elem := bq.elems[0]
-
-	// send the not empty signal again in case any remove method waits.
-	bq.notEmptyCond.Signal()
-
-	return elem
+	// No cascade Signal here: producers now Broadcast, so every waiter
+	// already re-checks its predicate.
+	return bq.elems[0]
 }
 
 // Size returns the number of elements in the queue.
@@ -292,7 +295,7 @@ func (bq *Blocking[T]) get() (v T, _ error) {
 	bq.elems[0] = zero
 	bq.elems = bq.elems[1:]
 
-	bq.notFullCond.Signal()
+	bq.notFullCond.Broadcast()
 
 	return elem, nil
 }

--- a/blocking_test.go
+++ b/blocking_test.go
@@ -35,6 +35,61 @@ func TestBlocking(t *testing.T) {
 	t.Run("NewDoesNotAliasCallerSlice", testBlockingNewDoesNotAliasCallerSlice)
 	t.Run("GetReleasesReference", testBlockingGetReleasesReference)
 	t.Run("ClearReleasesReferences", testBlockingClearReleasesReferences)
+	t.Run("OfferBroadcastsToAllWaiters", testBlockingOfferBroadcastsToAllWaiters)
+}
+
+// testBlockingOfferBroadcastsToAllWaiters documents that a single Offer
+// wakes every PeekWait waiter, not just one — so PeekWait does not need to
+// re-signal notEmptyCond to propagate wake-ups through a chain of peekers.
+// Regression guard for the cascade removal.
+func testBlockingOfferBroadcastsToAllWaiters(t *testing.T) {
+	t.Parallel()
+
+	const peekers = 10
+
+	blockingQueue := queue.NewBlocking[int](nil)
+
+	var wg sync.WaitGroup
+
+	wg.Add(peekers)
+
+	results := make(chan int, peekers)
+
+	for i := 0; i < peekers; i++ {
+		go func() {
+			defer wg.Done()
+
+			results <- blockingQueue.PeekWait()
+		}()
+	}
+
+	// Give the peekers a chance to enter Wait().
+	time.Sleep(50 * time.Millisecond)
+
+	if err := blockingQueue.Offer(42); err != nil {
+		t.Fatalf("offer: %v", err)
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("not every peeker was woken by a single Offer")
+	}
+
+	close(results)
+
+	for v := range results {
+		if v != 42 {
+			t.Fatalf("peek got %d want 42", v)
+		}
+	}
 }
 
 func testBlockingGetReleasesReference(t *testing.T) {


### PR DESCRIPTION
## Summary
- Previously `Offer` / `OfferWait` / `GetWait` / `get` each signalled one waiter, and `PeekWait` re-signalled `notEmptyCond` "in case any remove method waits". The cascade was correct only because `Signal` usually woke a peeker before a getter.
- Switch to `Broadcast` so every waiter re-checks its predicate (standard cond-var idiom), and drop the re-signal in `PeekWait`.
- Also zero the popped slot in `GetWait` — same pointer-retention fix as `Get`/`Clear` from #43, applied to the blocking removal path I missed.

Added a regression-guard test first (commit 1) that fails if someone drops the cascade without also switching producers to Broadcast. Then the fix (commit 2).

Fixes #46

## Test plan
- [x] `go test -race -shuffle=on .`
- [x] `golangci-lint run` passes locally.
- [x] Existing concurrency tests (`PeekWaitAndPushWaiting`, `ResetWhileMoreRoutinesThanElementsAreWaiting`) pass.