### PR TITLE
docs(readme): bust OpenSSF badge cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/adrianbrad/queue)](https://goreportcard.com/report/github.com/adrianbrad/queue)
 [![codecov](https://codecov.io/gh/adrianbrad/queue/branch/main/graph/badge.svg)](https://codecov.io/gh/adrianbrad/queue)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/adrianbrad/queue/badge)](https://scorecard.dev/viewer/?uri=github.com/adrianbrad/queue)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12607/badge)](https://www.bestpractices.dev/projects/12607)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12607/badge?v=1)](https://www.bestpractices.dev/projects/12607)
 
 [![lint-test](https://github.com/adrianbrad/queue/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/adrianbrad/queue/actions?query=workflow%3Alint-test)
 [![grype](https://github.com/adrianbrad/queue/actions/workflows/grype.yaml/badge.svg)](https://github.com/adrianbrad/queue/actions?query=workflow%3Agrype)


### PR DESCRIPTION
The OpenSSF Best Practices badge on the repo home page was still rendering as "in progress" after the project reached 100% at bestpractices.dev.

Root cause is Fastly in front of bestpractices.dev: different Fastly PoPs hold different cached copies, and the one GitHub's camo proxy happens to reach is still serving the stale SVG. Direct fetches from other PoPs return the fresh "passing" SVG, and `cache-control: no-store` on the origin doesn't help once Fastly has cached it.

Fastly keys by URL, so appending a cache-buster (`?v=1`) creates a new cache entry that has to go to origin, bypassing the stale one. Bump the number the next time this happens.