### PR TITLE
ci(dependabot): group minor and patch updates into a single PR

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,13 @@ updates:
       prefix: "build(deps)"
     reviewers:
       - "adrianbrad"
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -21,3 +28,10 @@ updates:
       prefix: "build(deps)"
     reviewers:
       - "adrianbrad"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -21,14 +21,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Approve PR
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.dependency-group != ''
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.dependency-group != ''
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary

- Add `groups` config to both Dependabot ecosystems (`gomod`, `github-actions`) so all minor + patch bumps land in a single weekly PR per ecosystem instead of one PR per dep.
- Major versions remain outside the group and continue to open individual PRs for isolated review of breaking changes.
- Extend the auto-merge condition in `dependabot-auto-merge.yaml` to also fire when `dependency-group` is set, since grouped PRs leave `update-type` empty. Safe because grouping is restricted to minor/patch only.

## Test plan

- [ ] After merge, manually trigger Dependabot via Insights -> Dependency graph -> Dependabot -> "Check for updates", or wait for the next Monday 06:00 schedule.
- [ ] Confirm a single PR titled `build(deps): bump the github-actions group with N updates` opens instead of N separate PRs.
- [ ] Confirm `dependabot-auto-merge` approves and squash-merges the grouped PR once required checks pass.
- [ ] When a major bump arrives next, confirm it opens its own PR outside the group.